### PR TITLE
further allowing mdel and mod in the output collation

### DIFF
--- a/collationChunks/C20/output/Collation_C20-complete-old.xml
+++ b/collationChunks/C20/output/Collation_C20-complete-old.xml
@@ -78,7 +78,8 @@
 				n="c57-0031__main__3"/&gt;&lt;anchor xml:id="c57-0031.03"/&gt;&lt;lb
 				n="c57-0031__left_margin__1"/&gt; &lt;del rend="strikethrough"
 				xml:id="c57-0031__left_margin__d4e4843"&gt; of th &lt;/del&gt; &lt;anchor
-				xml:id="c57-0031.01"/&gt; &lt;mdel&gt;of&lt;/mdel&gt; &lt;sga-add place="sublinear"
+				xml:id="c57-0031.01"/&gt;&lt;mod sID="c57-0031__main__d4e4849"/&gt;
+				&lt;mdel&gt;of&lt;/mdel&gt; &lt;sga-add place="sublinear"
 				sID="c57-0031__main__d4e4853"/&gt; &lt;metamark
 				function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
 				eID="c57-0031__main__d4e4853"/&gt;&lt;sga-add place="superlinear"
@@ -92,8 +93,8 @@
 			<rdg wit="f1823">the history of my friends. It was one </rdg>
 			<rdg wit="fThomas">the history of my friends. It was one </rdg>
 			<rdg wit="f1831">the history of my friends. It was one </rdg>
-			<rdg wit="fMS">&lt;sga-add eID="c57-0031__main__d4e4859"/&gt;the history of my friends.
-				It was one</rdg>
+			<rdg wit="fMS">&lt;sga-add eID="c57-0031__main__d4e4859"/&gt;&lt;mod
+				eID="c57-0031__main__d4e4849"/&gt;the history of my friends. It was one</rdg>
 		</rdgGrp>
 	</app>
 
@@ -118,11 +119,14 @@
 
 	<app>
 		<rdgGrp n="['on']">
-			<rdg wit="f1818">on </rdg>
-			<rdg wit="f1823">on </rdg>
-			<rdg wit="fThomas">on </rdg>
-			<rdg wit="f1831">on </rdg>
-			<rdg wit="fMS">&lt;mdel&gt;in&lt;/mdel&gt;&lt;sga-add hand="#pbs" place="superlinear"
+			<rdg wit="f1818">on</rdg>
+			<rdg wit="f1823">on</rdg>
+			<rdg wit="fThomas">on</rdg>
+			<rdg wit="f1831">on</rdg>
+		</rdgGrp>
+		<rdgGrp n="['', '', 'on']">
+			<rdg wit="fMS">&lt;mod sID="c57-0031__main__d4e4881"/&gt; &lt;mdel&gt;in&lt;/mdel&gt;
+				&lt;sga-add hand="#pbs" place="superlinear"
 				sID="c57-0031__main__d4e4885"/&gt;on</rdg>
 		</rdgGrp>
 	</app>
@@ -133,7 +137,8 @@
 			<rdg wit="f1823">my </rdg>
 			<rdg wit="fThomas">my </rdg>
 			<rdg wit="f1831">my </rdg>
-			<rdg wit="fMS">&lt;sga-add eID="c57-0031__main__d4e4885"/&gt;my</rdg>
+			<rdg wit="fMS">&lt;sga-add eID="c57-0031__main__d4e4885"/&gt;&lt;mod
+				eID="c57-0031__main__d4e4881"/&gt;my</rdg>
 		</rdgGrp>
 	</app>
 
@@ -347,13 +352,16 @@
 
 	<app>
 		<rdgGrp n="['in', 'the', 'service', 'of', 'his']">
-			<rdg wit="f1818">in the ser&lt;pb xml:id="F1818_v2_089" n="085"/&gt;vice of his </rdg>
-			<rdg wit="f1823">in the ser&lt;pb xml:id="F1823_v2_290" n="17"/&gt;vice of his </rdg>
-			<rdg wit="fThomas">in the ser&lt;pb xml:id="F1818_v2_089" n="085"/&gt;vice of his </rdg>
-			<rdg wit="f1831">in the service of his </rdg>
-			<rdg wit="fMS">&lt;mdel&gt;t&lt;/mdel&gt;&lt;sga-add place="intralinear"
-				sID="c57-0031__main__d4e4943"/&gt;i&lt;sga-add eID="c57-0031__main__d4e4943"/&gt;n
-				the service of his</rdg>
+			<rdg wit="f1818">in the ser&lt;pb xml:id="F1818_v2_089" n="085"/&gt;vice of his</rdg>
+			<rdg wit="f1823">in the ser&lt;pb xml:id="F1823_v2_290" n="17"/&gt;vice of his</rdg>
+			<rdg wit="fThomas">in the ser&lt;pb xml:id="F1818_v2_089" n="085"/&gt;vice of his</rdg>
+			<rdg wit="f1831">in the service of his</rdg>
+		</rdgGrp>
+		<rdgGrp n="['', '', 'in', 'the', 'service', 'of', 'his']">
+			<rdg wit="fMS">&lt;mod sID="c57-0031__main__d4e4939"/&gt; &lt;mdel&gt;t&lt;/mdel&gt;
+				&lt;sga-add place="intralinear" sID="c57-0031__main__d4e4943"/&gt;i&lt;sga-add
+				eID="c57-0031__main__d4e4943"/&gt;&lt;mod eID="c57-0031__main__d4e4939"/&gt;n the
+				service of his</rdg>
 		</rdgGrp>
 	</app>
 
@@ -384,8 +392,8 @@
 			<rdg wit="fThomas">ranked</rdg>
 			<rdg wit="f1831">ranked</rdg>
 		</rdgGrp>
-		<rdgGrp n="['&lt;delstart/&gt;been&lt;delend/&gt;', 'ranked']">
-			<rdg wit="fMS">&lt;del rend="strikethrough"
+		<rdgGrp n="['', '&lt;delstart/&gt;been&lt;delend/&gt;', 'ranked']">
+			<rdg wit="fMS">&lt;mod sID="c57-0031__main__d4e4949"/&gt; &lt;del rend="strikethrough"
 				xml:id="c57-0031__main__d4e4951"&gt;been&lt;/del&gt; &lt;sga-add place="superlinear"
 				sID="c57-0031__main__d4e4954"/&gt;ranked</rdg>
 		</rdgGrp>
@@ -413,8 +421,9 @@
 			<rdg wit="f1823">of the highest distinction. A few months </rdg>
 			<rdg wit="fThomas">of the highest distinction. A few months </rdg>
 			<rdg wit="f1831">of the highest distinction. A few months </rdg>
-			<rdg wit="fMS">&lt;sga-add eID="c57-0031__main__d4e4963"/&gt;of the &lt;lb
-				n="c57-0031__main__16"/&gt;highest distinction. A few months</rdg>
+			<rdg wit="fMS">&lt;sga-add eID="c57-0031__main__d4e4963"/&gt;&lt;mod
+				eID="c57-0031__main__d4e4949"/&gt;of the &lt;lb n="c57-0031__main__16"/&gt;highest
+				distinction. A few months</rdg>
 		</rdgGrp>
 	</app>
 
@@ -516,17 +525,20 @@
 			<rdg wit="fThomas">which</rdg>
 			<rdg wit="f1831">which</rdg>
 		</rdgGrp>
-		<rdgGrp n="['that', '&lt;delstart/&gt;that&lt;delend/&gt;', 'which']">
-			<rdg wit="fMS">that &lt;del rend="strikethrough"
-				xml:id="c57-0031__main__d4e4994"&gt;that&lt;/del&gt; &lt;sga-add hand="#pbs"
-				place="superlinear" sID="c57-0031__main__d4e4997"/&gt;which</rdg>
+		<rdgGrp n="['that', '', '&lt;delstart/&gt;that&lt;delend/&gt;', 'which']">
+			<rdg wit="fMS">that &lt;mod sID="c57-0031__main__d4e4992"/&gt; &lt;del
+				rend="strikethrough" xml:id="c57-0031__main__d4e4994"&gt;that&lt;/del&gt;
+				&lt;sga-add hand="#pbs" place="superlinear"
+				sID="c57-0031__main__d4e4997"/&gt;which</rdg>
 		</rdgGrp>
 	</app>
 
 	<app>
 		<rdgGrp n="['', 'virtue', '', '', 'and']">
-			<rdg wit="fMS">&lt;sga-add eID="c57-0031__main__d4e4997"/&gt; virtue &lt;sga-add
-				place="sublinear" sID="c57-0031__main__d4e5003"/&gt; &lt;metamark
+			<rdg wit="fMS">&lt;sga-add eID="c57-0031__main__d4e4997"/&gt;&lt;mod
+				eID="c57-0031__main__d4e4992"/&gt; virtue &lt;mod
+				sID="c57-0031__main__d4e5001"/&gt;&lt;sga-add place="sublinear"
+				sID="c57-0031__main__d4e5003"/&gt; &lt;metamark
 				function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
 				eID="c57-0031__main__d4e5003"/&gt;&lt;sga-add hand="#pbs" next="#c57-0031.10"
 				place="superlinear" sID="c57-0031__main__d4e5009"/&gt;&amp;</rdg>
@@ -564,9 +576,9 @@
 			<rdg wit="f1823">taste, accompanied</rdg>
 			<rdg wit="fThomas">taste, accompanied</rdg>
 			<rdg wit="f1831">taste, accompanied</rdg>
-			<rdg wit="fMS">taste, &lt;sga-add eID="c57-0031__main__d4e5009"/&gt;&lt;w
-				ana="start"/&gt;ac&lt;lb n="c57-0031__main__20"/&gt;companied&lt;w
-				ana="end"/&gt;</rdg>
+			<rdg wit="fMS">taste, &lt;sga-add eID="c57-0031__main__d4e5009"/&gt;&lt;mod
+				eID="c57-0031__main__d4e5001"/&gt;&lt;w ana="start"/&gt;ac&lt;lb
+				n="c57-0031__main__20"/&gt;companied&lt;w ana="end"/&gt;</rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -641,8 +653,8 @@
 			<rdg wit="fThomas">had been</rdg>
 			<rdg wit="f1831">had been</rdg>
 		</rdgGrp>
-		<rdgGrp n="['&lt;delstart/&gt;was&lt;delend/&gt;', 'had', 'been']">
-			<rdg wit="fMS">&lt;del rend="strikethrough"
+		<rdgGrp n="['', '&lt;delstart/&gt;was&lt;delend/&gt;', 'had', 'been']">
+			<rdg wit="fMS">&lt;mod sID="c57-0031__main__d4e5027"/&gt; &lt;del rend="strikethrough"
 				xml:id="c57-0031__main__d4e5029"&gt;was&lt;/del&gt; &lt;sga-add place="superlinear"
 				sID="c57-0031__main__d4e5032"/&gt;had been</rdg>
 		</rdgGrp>
@@ -654,16 +666,18 @@
 			<rdg wit="f1823">the cause of their </rdg>
 			<rdg wit="fThomas">the cause of their </rdg>
 			<rdg wit="f1831">the cause of their </rdg>
-			<rdg wit="fMS">&lt;sga-add eID="c57-0031__main__d4e5032"/&gt;the cause of their</rdg>
+			<rdg wit="fMS">&lt;sga-add eID="c57-0031__main__d4e5032"/&gt;&lt;mod
+				eID="c57-0031__main__d4e5027"/&gt;the cause of their</rdg>
 		</rdgGrp>
 	</app>
 
 	<app>
 		<rdgGrp n="['', '&lt;delstart/&gt;fall&lt;delend/&gt;', 'ruin;', '']">
-			<rdg wit="fMS">&lt;lb n="c57-0031__main__23"/&gt; &lt;del rend="strikethrough"
+			<rdg wit="fMS">&lt;lb n="c57-0031__main__23"/&gt;&lt;mod
+				sID="c57-0031__main__d4e5038"/&gt; &lt;del rend="strikethrough"
 				xml:id="c57-0031__main__d4e5040"&gt;fall&lt;/del&gt; &lt;sga-add hand="#pbs"
 				place="superlinear" sID="c57-0031__main__d4e5043"/&gt;ruin; &lt;sga-add
-				eID="c57-0031__main__d4e5043"/&gt;</rdg>
+				eID="c57-0031__main__d4e5043"/&gt;&lt;mod eID="c57-0031__main__d4e5038"/&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp n="['ruin.']">
 			<rdg wit="f1818">ruin.</rdg>
@@ -683,13 +697,16 @@
 	</app>
 	<app>
 		<rdgGrp n="['turkish']">
-			<rdg wit="f1818">Turkish </rdg>
-			<rdg wit="f1823">Turkish </rdg>
-			<rdg wit="fThomas">Turkish </rdg>
-			<rdg wit="f1831">Turkish </rdg>
-			<rdg wit="fMS">&lt;mdel&gt;t&lt;/mdel&gt;&lt;sga-add place="intralinear"
-				sID="c57-0031__main__d4e5051"/&gt;T&lt;sga-add
-				eID="c57-0031__main__d4e5051"/&gt;urkish</rdg>
+			<rdg wit="f1818">Turkish</rdg>
+			<rdg wit="f1823">Turkish</rdg>
+			<rdg wit="fThomas">Turkish</rdg>
+			<rdg wit="f1831">Turkish</rdg>
+		</rdgGrp>
+		<rdgGrp n="['', '', 'turkish']">
+			<rdg wit="fMS">&lt;mod sID="c57-0031__main__d4e5047"/&gt; &lt;mdel&gt;t&lt;/mdel&gt;
+				&lt;sga-add place="intralinear" sID="c57-0031__main__d4e5051"/&gt;T&lt;sga-add
+				eID="c57-0031__main__d4e5051"/&gt;&lt;mod
+				eID="c57-0031__main__d4e5047"/&gt;urkish</rdg>
 		</rdgGrp>
 	</app>
 
@@ -735,10 +752,11 @@
 			<rdg wit="f1831">years, when,</rdg>
 		</rdgGrp>
 		<rdgGrp
-			n="['years.', 'when', 'his', 'person', 'became', '&lt;delstart/&gt;for some&lt;delend/&gt;', '', '']">
-			<rdg wit="fMS">years. When his person &lt;lb n="c57-0031__main__25"/&gt;became &lt;del
-				rend="strikethrough" xml:id="c57-0031__main__d4e5065"&gt;for some&lt;/del&gt;
-				&lt;sga-add place="sublinear" sID="c57-0031__main__d4e5068"/&gt; &lt;metamark
+			n="['years.', 'when', 'his', 'person', 'became', '', '&lt;delstart/&gt;for some&lt;delend/&gt;', '', '']">
+			<rdg wit="fMS">years. When his person &lt;lb n="c57-0031__main__25"/&gt;became &lt;mod
+				sID="c57-0031__main__d4e5063"/&gt; &lt;del rend="strikethrough"
+				xml:id="c57-0031__main__d4e5065"&gt;for some&lt;/del&gt; &lt;sga-add
+				place="sublinear" sID="c57-0031__main__d4e5068"/&gt; &lt;metamark
 				function="insert"&gt;^&lt;/metamark&gt;</rdg>
 		</rdgGrp>
 	</app>
@@ -755,7 +773,8 @@
 	</app>
 	<app>
 		<rdgGrp n="['learn', '']">
-			<rdg wit="fMS">learn &lt;sga-add eID="c57-0031__main__d4e5074"/&gt;</rdg>
+			<rdg wit="fMS">learn &lt;sga-add eID="c57-0031__main__d4e5074"/&gt;&lt;mod
+				eID="c57-0031__main__d4e5063"/&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp n="['learn,', 'he', 'became']">
 			<rdg wit="f1818">learn, he became</rdg>
@@ -889,9 +908,10 @@
 			n="['wealth', '', '&lt;delstart/&gt;had been the causes of his condemnation rather&lt;delend/&gt;', '', '&lt;delstart/&gt;than&lt;delend/&gt;']">
 			<rdg wit="fMS">wealth &lt;lb n="c57-0031__main__32"/&gt; &lt;del rend="strikethrough"
 				xml:id="c57-0031__main__d4e5105"&gt;had been the causes of his condemnation
-				rather&lt;/del&gt; &lt;lb n="c57-0032__main__1"/&gt;&lt;anchor
-				xml:id="c57-0032.01"/&gt;&lt;lb n="c57-0032__left_margin__1"/&gt; &lt;del
-				rend="smear" xml:id="c57-0032__left_margin__d4e5126"&gt;than&lt;/del&gt;</rdg>
+				rather&lt;/del&gt; &lt;lb n="c57-0032__main__1"/&gt;&lt;mod
+				sID="c57-0032__main__d4e5118"/&gt;&lt;anchor xml:id="c57-0032.01"/&gt;&lt;lb
+				n="c57-0032__left_margin__1"/&gt; &lt;del rend="smear"
+				xml:id="c57-0032__left_margin__d4e5126"&gt;than&lt;/del&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp n="['wealth,']">
 			<rdg wit="f1818">wealth,</rdg>
@@ -918,7 +938,8 @@
 			<rdg wit="f1823">the &lt;pb xml:id="F1823_v2_291" n="18"/&gt;crime </rdg>
 			<rdg wit="fThomas">the &lt;pb xml:id="F1818_v2_090" n="086"/&gt;crime </rdg>
 			<rdg wit="f1831">the crime </rdg>
-			<rdg wit="fMS">&lt;sga-add eID="c57-0032__main__d4e5133"/&gt;the crime</rdg>
+			<rdg wit="fMS">&lt;sga-add eID="c57-0032__main__d4e5133"/&gt;&lt;mod
+				eID="c57-0032__main__d4e5118"/&gt;the crime</rdg>
 		</rdgGrp>
 	</app>
 
@@ -1018,12 +1039,16 @@
 	</app>
 	<app>
 		<rdgGrp n="['', '', 'w', '', 'ere', '', 'uncontrolable']">
-			<rdg wit="fMS">&lt;sga-add place="sublinear" sID="c57-0032__main__d4e5165"/&gt;
-				&lt;metamark function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
+			<rdg wit="fMS">&lt;mod sID="c57-0032__main__d4e5163"/&gt;&lt;sga-add place="sublinear"
+				sID="c57-0032__main__d4e5165"/&gt; &lt;metamark
+				function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
 				eID="c57-0032__main__d4e5165"/&gt;&lt;sga-add place="superlinear"
-				sID="c57-0032__main__d4e5171"/&gt;w &lt;mdel&gt;as&lt;/mdel&gt; &lt;sga-add
-				hand="#pbs" place="intralinear" sID="c57-0032__main__d4e5177"/&gt;ere &lt;sga-add
-				eID="c57-0032__main__d4e5177"/&gt;&lt;sga-add eID="c57-0032__main__d4e5171"/&gt;
+				sID="c57-0032__main__d4e5171"/&gt;w&lt;mod sID="c57-0032__main__d4e5173"/&gt;
+				&lt;mdel&gt;as&lt;/mdel&gt; &lt;sga-add hand="#pbs" place="intralinear"
+				sID="c57-0032__main__d4e5177"/&gt;ere &lt;sga-add
+				eID="c57-0032__main__d4e5177"/&gt;&lt;mod
+				eID="c57-0032__main__d4e5173"/&gt;&lt;sga-add
+				eID="c57-0032__main__d4e5171"/&gt;&lt;mod eID="c57-0032__main__d4e5163"/&gt;
 				uncontrolable</rdg>
 		</rdgGrp>
 		<rdgGrp n="['were', 'uncontrollable,']">
@@ -1051,7 +1076,8 @@
 		</rdgGrp>
 		<rdgGrp
 			n="['', '&lt;delstart/&gt;event.&lt;delend/&gt;', '', '', 'decision', 'of', 'the', 'court.']">
-			<rdg wit="fMS">&lt;lb n="c57-0032__main__4"/&gt; &lt;del rend="strikethrough"
+			<rdg wit="fMS">&lt;lb n="c57-0032__main__4"/&gt;&lt;mod
+				sID="c57-0032__main__d4e5185"/&gt; &lt;del rend="strikethrough"
 				xml:id="c57-0032__main__d4e5187"&gt;event.&lt;/del&gt; &lt;sga-add hand="#pbs"
 				place="superlinear" sID="c57-0032__main__d4e5190"/&gt; &lt;mdel&gt;of&lt;/mdel&gt;
 				decision of the court.</rdg>
@@ -1064,7 +1090,8 @@
 			<rdg wit="f1823">He </rdg>
 			<rdg wit="fThomas">He </rdg>
 			<rdg wit="f1831">He </rdg>
-			<rdg wit="fMS">&lt;sga-add eID="c57-0032__main__d4e5190"/&gt;He</rdg>
+			<rdg wit="fMS">&lt;sga-add eID="c57-0032__main__d4e5190"/&gt;&lt;mod
+				eID="c57-0032__main__d4e5185"/&gt;He</rdg>
 		</rdgGrp>
 	</app>
 
@@ -1139,10 +1166,11 @@
 		<rdgGrp n="['prison', '&lt;delstart/&gt;goal&lt;delend/&gt;', 'prison', '']">
 			<rdg wit="fMS">&lt;delSpan rend="strikethrough" spanTo="#c57-0032.04"/&gt;&lt;w
 				ana="start"/&gt;pri&lt;lb n="c57-0032__main__8"/&gt;son&lt;w
-				ana="end"/&gt;&lt;anchor xml:id="c57-0032.04"/&gt; &lt;del rend="strikethrough"
+				ana="end"/&gt;&lt;anchor xml:id="c57-0032.04"/&gt;&lt;mod
+				sID="c57-0032__main__d4e5214"/&gt; &lt;del rend="strikethrough"
 				xml:id="c57-0032__main__d4e5216"&gt;goal&lt;/del&gt; &lt;sga-add hand="#pbs"
 				place="superlinear" sID="c57-0032__main__d4e5219"/&gt;prison &lt;sga-add
-				eID="c57-0032__main__d4e5219"/&gt;</rdg>
+				eID="c57-0032__main__d4e5219"/&gt;&lt;mod eID="c57-0032__main__d4e5214"/&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp n="['prison,']">
 			<rdg wit="f1818">prison,</rdg>
@@ -1162,10 +1190,12 @@
 	</app>
 	<app>
 		<rdgGrp n="['st', '', '', 'r', '', 'ongly']">
-			<rdg wit="fMS">st &lt;sga-add place="sublinear" sID="c57-0032__main__d4e5225"/&gt;
-				&lt;metamark function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
+			<rdg wit="fMS">st &lt;mod sID="c57-0032__main__d4e5223"/&gt;&lt;sga-add
+				place="sublinear" sID="c57-0032__main__d4e5225"/&gt; &lt;metamark
+				function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
 				eID="c57-0032__main__d4e5225"/&gt;&lt;sga-add place="superlinear"
-				sID="c57-0032__main__d4e5231"/&gt;r &lt;sga-add eID="c57-0032__main__d4e5231"/&gt;
+				sID="c57-0032__main__d4e5231"/&gt;r &lt;sga-add
+				eID="c57-0032__main__d4e5231"/&gt;&lt;mod eID="c57-0032__main__d4e5223"/&gt;
 				ongly</rdg>
 		</rdgGrp>
 		<rdgGrp n="['strongly']">
@@ -1192,11 +1222,12 @@
 			<rdg wit="fThomas">building, which</rdg>
 			<rdg wit="f1831">building, which</rdg>
 		</rdgGrp>
-		<rdgGrp n="['&lt;delstart/&gt;prison&lt;delend/&gt;', 'building,', 'which']">
-			<rdg wit="fMS">&lt;del rend="strikethrough"
+		<rdgGrp n="['', '&lt;delstart/&gt;prison&lt;delend/&gt;', 'building,', 'which']">
+			<rdg wit="fMS">&lt;mod sID="c57-0032__main__d4e5237"/&gt; &lt;del rend="strikethrough"
 				xml:id="c57-0032__main__d4e5239"&gt;prison&lt;/del&gt; &lt;sga-add hand="#pbs"
 				place="superlinear" sID="c57-0032__main__d4e5242"/&gt;building, &lt;sga-add
-				eID="c57-0032__main__d4e5242"/&gt;&lt;lb n="c57-0032__main__10"/&gt;which</rdg>
+				eID="c57-0032__main__d4e5242"/&gt;&lt;mod eID="c57-0032__main__d4e5237"/&gt;&lt;lb
+				n="c57-0032__main__10"/&gt;which</rdg>
 		</rdgGrp>
 	</app>
 
@@ -1343,13 +1374,15 @@
 			<rdg wit="fThomas">kindle the zeal of his</rdg>
 			<rdg wit="f1831">kindle the zeal of his</rdg>
 		</rdgGrp>
-		<rdgGrp n="['&lt;delstart/&gt;warm&lt;delend/&gt;', 'kindle', 'the', 'zeal', 'of', 'his']">
-			<rdg wit="fMS">&lt;del rend="strikethrough"
+		<rdgGrp
+			n="['', '&lt;delstart/&gt;warm&lt;delend/&gt;', 'kindle', 'the', 'zeal', 'of', 'his']">
+			<rdg wit="fMS">&lt;mod sID="c57-0032__main__d4e5281"/&gt; &lt;del rend="strikethrough"
 				xml:id="c57-0032__main__d4e5283"&gt;warm&lt;/del&gt; &lt;anchor
 				xml:id="c57-0032.05"/&gt;&lt;lb n="c57-0032__left_margin__1"/&gt;&lt;sga-add
 				hand="#pbs" sID="c57-0032__left_margin__d4e5292"/&gt;kindle &lt;sga-add
-				eID="c57-0032__left_margin__d4e5292"/&gt;&lt;lb n="c57-0032__main__18"/&gt;the zeal
-				of his</rdg>
+				eID="c57-0032__left_margin__d4e5292"/&gt;&lt;mod
+				eID="c57-0032__main__d4e5281"/&gt;&lt;lb n="c57-0032__main__18"/&gt;the zeal of
+				his</rdg>
 		</rdgGrp>
 	</app>
 
@@ -1523,13 +1556,15 @@
 				sID="novel1_letter4_chapter14_div4_div14_p5"/&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp
-			n="['', '', '', '&lt;delstart/&gt;', 'altho it had not', 'en ', '&lt;delend/&gt;', 'would', 'fully', 'reward', 'his', 'toil', 'and', 'hazard.', '&lt;p-end/&gt;', '&lt;p-start/&gt;']">
-			<rdg wit="fMS">&lt;sga-add place="sublinear" sID="c57-0032__main__d4e5325"/&gt;
-				&lt;metamark function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
+			n="['', '', '', '&lt;delstart/&gt;', 'altho it had not', 'en ', '&lt;delend/&gt;', '', 'would', 'fully', 'reward', 'his', 'toil', 'and', 'hazard.', '&lt;p-end/&gt;', '&lt;p-start/&gt;']">
+			<rdg wit="fMS">&lt;mod sID="c57-0032__main__d4e5323"/&gt;&lt;sga-add place="sublinear"
+				sID="c57-0032__main__d4e5325"/&gt; &lt;metamark
+				function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
 				eID="c57-0032__main__d4e5325"/&gt; &lt;del rend="strikethrough"
 				xml:id="c57-0032__main__d4e5331"&gt; &lt;sga-add hand="#pbs" place="superlinear"
 				sID="c57-0032__main__d4e5333"/&gt;altho it had not en &lt;sga-add
-				eID="c57-0032__main__d4e5333"/&gt; &lt;/del&gt; would fully reward his &lt;lb
+				eID="c57-0032__main__d4e5333"/&gt; &lt;/del&gt; &lt;mod
+				eID="c57-0032__main__d4e5323"/&gt; would fully reward his &lt;lb
 				n="c57-0032__main__27"/&gt;toil &amp; hazard. &lt;milestone unit="tei:p-END"/&gt;
 				&lt;milestone unit="tei:p-START"/&gt;</rdg>
 		</rdgGrp>
@@ -1608,13 +1643,13 @@
 	</app>
 	<app>
 		<rdgGrp
-			n="['&lt;delstart/&gt;re ', '&lt;mod sid=&#34;c57-0033__main__d4e5375&#34;/&gt;', '&lt;mdel&gt;', '&lt;/mdel&gt;', 's ', '&lt;mod eid=&#34;c57-0033__main__d4e5375&#34;/&gt; olved&lt;delend/&gt;', 'endeavored']">
-			<rdg wit="fMS">&lt;del rend="strikethrough" xml:id="c57-0033__main__d4e5373"&gt;re
-				&lt;mod sID="c57-0033__main__d4e5375"/&gt; &lt;mdel&gt; &lt;/mdel&gt; &lt;sga-add
-				place="intralinear" sID="c57-0033__main__d4e5382"/&gt;s &lt;sga-add
-				eID="c57-0033__main__d4e5382"/&gt; &lt;mod eID="c57-0033__main__d4e5375"/&gt;
-				olved&lt;/del&gt; &lt;anchor xml:id="c57-0033.02"/&gt;&lt;lb
-				n="c57-0033__left_margin__1"/&gt;&lt;sga-add
+			n="['', '&lt;delstart/&gt;re ', '', '&lt;mdel&gt;', '&lt;/mdel&gt;', 's ', 'olved&lt;delend/&gt;', 'endeavored']">
+			<rdg wit="fMS">&lt;mod sID="c57-0033__main__d4e5371"/&gt; &lt;del rend="strikethrough"
+				xml:id="c57-0033__main__d4e5373"&gt;re &lt;mod sID="c57-0033__main__d4e5375"/&gt;
+				&lt;mdel&gt; &lt;/mdel&gt; &lt;sga-add place="intralinear"
+				sID="c57-0033__main__d4e5382"/&gt;s &lt;sga-add eID="c57-0033__main__d4e5382"/&gt;
+				&lt;mod eID="c57-0033__main__d4e5375"/&gt; olved&lt;/del&gt; &lt;anchor
+				xml:id="c57-0033.02"/&gt;&lt;lb n="c57-0033__left_margin__1"/&gt;&lt;sga-add
 				sID="c57-0033__left_margin__d4e5393"/&gt;endeavored</rdg>
 		</rdgGrp>
 		<rdgGrp n="['endeavoured']">
@@ -1630,8 +1665,8 @@
 			<rdg wit="f1823">to secure</rdg>
 			<rdg wit="fThomas">to secure</rdg>
 			<rdg wit="f1831">to secure</rdg>
-			<rdg wit="fMS">&lt;sga-add eID="c57-0033__left_margin__d4e5393"/&gt;&lt;lb
-				n="c57-0033__main__3"/&gt;to secure</rdg>
+			<rdg wit="fMS">&lt;sga-add eID="c57-0033__left_margin__d4e5393"/&gt;&lt;mod
+				eID="c57-0033__main__d4e5371"/&gt;&lt;lb n="c57-0033__main__3"/&gt;to secure</rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -1656,13 +1691,14 @@
 			<rdg wit="fThomas">more entirely</rdg>
 			<rdg wit="f1831">more entirely</rdg>
 		</rdgGrp>
-		<rdgGrp n="['&lt;delstart/&gt;at any pr&lt;delend/&gt;', '', '', 'more', 'entirely']">
-			<rdg wit="fMS">&lt;del rend="strikethrough" xml:id="c57-0033__main__d4e5407"&gt;at any
-				pr&lt;/del&gt; &lt;sga-add place="sublinear" sID="c57-0033__main__d4e5410"/&gt;
-				&lt;metamark function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
+		<rdgGrp n="['', '&lt;delstart/&gt;at any pr&lt;delend/&gt;', '', '', 'more', 'entirely']">
+			<rdg wit="fMS">&lt;mod sID="c57-0033__main__d4e5405"/&gt; &lt;del rend="strikethrough"
+				xml:id="c57-0033__main__d4e5407"&gt;at any pr&lt;/del&gt; &lt;sga-add
+				place="sublinear" sID="c57-0033__main__d4e5410"/&gt; &lt;metamark
+				function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
 				eID="c57-0033__main__d4e5410"/&gt;&lt;sga-add place="superlinear"
 				sID="c57-0033__main__d4e5416"/&gt;more entirely&lt;sga-add
-				eID="c57-0033__main__d4e5416"/&gt;</rdg>
+				eID="c57-0033__main__d4e5416"/&gt;&lt;mod eID="c57-0033__main__d4e5405"/&gt;</rdg>
 		</rdgGrp>
 	</app>
 
@@ -1707,12 +1743,13 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['&lt;delstart/&gt;', 'offer ', '&lt;delend/&gt;', 'offer', '']">
-			<rdg wit="fMS">&lt;del rend="strikethrough" xml:id="c57-0033__main__d4e5427"&gt;
-				&lt;sga-add hand="#pbs" place="superlinear" sID="c57-0033__main__d4e5429"/&gt;offer
-				&lt;sga-add eID="c57-0033__main__d4e5429"/&gt; &lt;/del&gt; &lt;sga-add hand="#pbs"
+		<rdgGrp n="['', '&lt;delstart/&gt;', 'offer ', '&lt;delend/&gt;', 'offer', '']">
+			<rdg wit="fMS">&lt;mod sID="c57-0033__main__d4e5425"/&gt; &lt;del rend="strikethrough"
+				xml:id="c57-0033__main__d4e5427"&gt; &lt;sga-add hand="#pbs" place="superlinear"
+				sID="c57-0033__main__d4e5429"/&gt;offer &lt;sga-add
+				eID="c57-0033__main__d4e5429"/&gt; &lt;/del&gt; &lt;sga-add hand="#pbs"
 				place="superlinear" sID="c57-0033__main__d4e5439"/&gt;offer &lt;sga-add
-				eID="c57-0033__main__d4e5439"/&gt;</rdg>
+				eID="c57-0033__main__d4e5439"/&gt;&lt;mod eID="c57-0033__main__d4e5425"/&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp n="['this', 'offer;']">
 			<rdg wit="f1818">this offer;</rdg>
@@ -2149,8 +2186,9 @@
 			<rdg wit="fThomas">across Mont Cenis to Leghorn, where</rdg>
 			<rdg wit="f1831">across Mont Cenis to Leghorn, where</rdg>
 		</rdgGrp>
-		<rdgGrp n="['rank', '&lt;delstart/&gt;her father&lt;delend/&gt;']">
-			<rdg wit="fMS">rank &lt;del rend="strikethrough" xml:id="c57-0033__main__d4e5465"&gt;her
+		<rdgGrp n="['rank', '', '&lt;delstart/&gt;her father&lt;delend/&gt;']">
+			<rdg wit="fMS">rank &lt;mod sID="c57-0033__main__d4e5463"/&gt; &lt;del
+				rend="strikethrough" xml:id="c57-0033__main__d4e5465"&gt;her
 				father&lt;/del&gt;</rdg>
 		</rdgGrp>
 	</app>
@@ -2166,12 +2204,13 @@
 	</app>
 	<app>
 		<rdgGrp n="['', 'commander', '', '&lt;delstart/&gt;her&lt;delend/&gt;']">
-			<rdg wit="fMS">&lt;sga-add eID="c57-0033__main__d4e5468"/&gt; commander &lt;lb
-				n="c57-0033__main__13"/&gt; &lt;del rend="strikethrough"
-				xml:id="c57-0033__main__d4e5477"&gt;her&lt;/del&gt;</rdg>
+			<rdg wit="fMS">&lt;sga-add eID="c57-0033__main__d4e5468"/&gt;&lt;mod
+				eID="c57-0033__main__d4e5463"/&gt; commander &lt;lb
+				n="c57-0033__main__13"/&gt;&lt;mod sID="c57-0033__main__d4e5475"/&gt; &lt;del
+				rend="strikethrough" xml:id="c57-0033__main__d4e5477"&gt;her&lt;/del&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp
-			n="['had', 'decided', 'to', 'wait', 'a', 'favourable', 'opportunity', 'of', 'passing', 'into', 'some', 'part', 'of', 'the', 'turkish', 'dominions.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&#34;safie', 'resolved', 'to', 'remain', 'with', 'her', 'father', 'until', 'the', 'moment', 'of', 'his', 'departure,', 'before', 'which', 'time', 'the', 'turk', 'renewed', 'his', 'promise', 'that', 'she', 'should', 'be', 'united', 'to', 'his', 'deliverer;', 'and', 'felix', 'remained', 'with', 'them', 'in', 'expectation', 'of', 'that', 'event;', 'and', 'in', 'the', 'mean', 'time', 'he', 'enjoyed', 'the', 'society', 'of', 'the', 'arabian,', 'who', 'exhibited', 'towards', 'him', 'the', 'simplest', 'and', 'tenderest', 'affection.', 'they', 'conversed', 'with', 'one', 'another', 'through', 'the', 'means', 'of', 'an', 'interpreter,', 'and', 'sometimes', 'with', 'the', 'interpretation', 'of', 'looks;', 'and', 'safie', 'sang', 'to', 'him', 'the', 'divine', 'airs', 'of', 'her', 'native', 'country.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&#34;the', 'turk', 'allowed', 'this', 'intimacy', 'to', 'take', 'place,', 'and', 'encouraged', 'the', 'hopes', 'of', 'the', 'youthful', 'lovers,', 'while', 'in', 'his', 'heart', 'he', 'had', 'formed', 'far', 'other', 'plans.', 'he', 'loathed', 'the', 'idea', 'that', 'his', 'daughter', 'should', 'be', 'united', 'to', 'a', 'christian;', 'but', 'he', 'feared', 'the', 'resentment', 'of']">
+			n="['had', 'decided', 'to', 'wait', 'a', 'favourable', 'opportunity', 'of', 'passing', 'into', 'some', 'part', 'of', 'the', 'turkish', 'dominions.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&#34;safie', 'resolved', 'to', 'remain', 'with', 'her', 'father', 'until', 'the', 'moment', 'of', 'his', 'departure,', 'before', 'which', 'time', 'the', 'turk', 'renewed', 'his', 'promise', 'that', 'she', 'should', 'be', 'united', 'to', 'his', 'deliverer;', 'and', 'felix', 'remained', 'with', 'them', 'in', 'expectation', 'of', 'that', 'event;', 'and', 'in', 'the', 'mean', 'time', 'he', 'enjoyed', 'the', 'society', 'of', 'the', 'arabian,', 'who', 'exhibited', 'towards', 'him', 'the', 'simplest', 'and', 'tenderest', 'affection.', 'they', 'conversed', 'with', 'one', 'another', 'through', 'the', 'means', 'of', 'an', 'interpreter,', 'and', 'sometimes', 'with', 'the', 'interpretation', 'of', 'looks;', 'and', 'safie', 'sang', 'to', 'him', 'the', 'divine', 'airs', 'of', 'her', 'native', 'country.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&#34;the', 'turk', 'allowed', 'this', 'intimacy', 'to', 'take', 'place,', 'and', 'encouraged', 'the', 'hopes', 'of', 'the', 'youthful', 'lovers,', 'while', 'in', 'his', 'heart', 'he', 'had', 'formed', 'far', 'other', 'plans.', 'he', 'loathed', 'the', 'idea', 'that']">
 			<rdg wit="f1818">had decided to wait a favourable opportunity of passing into some part
 				of the Turkish dominions. &lt;p eID="novel1_letter4_chapter13_div4_div14_p10"/&gt;
 				&lt;p sID="novel1_letter4_chapter13_div4_div14_p11"/&gt; “Safie resolved to remain
@@ -2185,8 +2224,7 @@
 				eID="novel1_letter4_chapter13_div4_div14_p11"/&gt; &lt;p
 				sID="novel1_letter4_chapter13_div4_div14_p12"/&gt; “The Turk allowed this intimacy
 				to take place, and encouraged the hopes of the youthful lovers, while in his heart
-				he had formed far other plans. He loathed the idea that his daughter should be
-				united to a Christian; but he feared the resentment of</rdg>
+				he had formed far other plans. He loathed the idea that</rdg>
 			<rdg wit="f1823">had decided to wait a favourable opportunity of passing into some part
 				of the Turkish dominions. &lt;p eID="novel1_letter4_chapter13_div4_div14_p10"/&gt;
 				&lt;p sID="novel1_letter4_chapter13_div4_div14_p11"/&gt; “Safie resolved to remain
@@ -2200,8 +2238,7 @@
 				eID="novel1_letter4_chapter13_div4_div14_p11"/&gt; &lt;p
 				sID="novel1_letter4_chapter13_div4_div14_p12"/&gt; “The Turk allowed this intimacy
 				to take place, and encouraged the hopes of the youthful lovers, while in his heart
-				he had formed far other plans. He loathed the idea that his daughter should be
-				united to a Christian; but he feared the resentment of</rdg>
+				he had formed far other plans. He loathed the idea that</rdg>
 			<rdg wit="fThomas">had decided to wait a favourable opportunity of passing into some
 				part of the Turkish dominions. &lt;p
 				eID="novel1_letter4_chapter13_div4_div14_p10"/&gt; &lt;p
@@ -2216,8 +2253,7 @@
 				eID="novel1_letter4_chapter13_div4_div14_p11"/&gt; &lt;p
 				sID="novel1_letter4_chapter13_div4_div14_p12"/&gt; “The Turk allowed this intimacy
 				to take place, and encouraged the hopes of the youthful lovers, while in his heart
-				he had formed far other plans. He loathed the idea that his daughter should be
-				united to a Christian; but he feared the resentment of</rdg>
+				he had formed far other plans. He loathed the idea that</rdg>
 			<rdg wit="f1831">had decided to wait a favourable opportunity of passing into some part
 				of the Turkish dominions. &lt;p eID="novel1_letter4_chapter14_div4_div14_p10"/&gt;
 				&lt;p sID="novel1_letter4_chapter14_div4_div14_p11"/&gt; “Safie resolved to remain
@@ -2230,42 +2266,7 @@
 				country. &lt;p eID="novel1_letter4_chapter14_div4_div14_p11"/&gt; &lt;p
 				sID="novel1_letter4_chapter14_div4_div14_p12"/&gt; “The Turk allowed this intimacy
 				to take place, and encouraged the hopes of the youthful lovers, while in his heart
-				he had formed far other plans. He loathed the idea that his daughter should be
-				united to a Christian; but he feared the resentment of</rdg>
-		</rdgGrp>
-	</app>
-	<app>
-		<rdgGrp n="['felix']">
-			<rdg wit="f1818">Felix</rdg>
-			<rdg wit="fThomas">Felix</rdg>
-		</rdgGrp>
-		<rdgGrp n="['felix,']">
-			<rdg wit="f1823">Felix,</rdg>
-			<rdg wit="f1831">Felix,</rdg>
-		</rdgGrp>
-	</app>
-	<app>
-		<rdgGrp
-			n="['if', 'he', 'should', 'appear', 'lukewarm;', 'for', 'he', 'knew', 'that', 'he', 'was', 'still', 'in', 'the', 'power', 'of', 'his', 'deliverer,', 'if', 'he', 'should', 'choose', 'to', 'betray', 'him', 'to', 'the', 'italian', 'state', 'which', 'they', 'inhabited.', 'he', 'revolved', 'a', 'thousand', 'plans', 'by', 'which', 'he', 'should', 'be', 'enabled', 'to', 'prolong', 'the', 'deceit', 'until', 'it', 'might', 'be', 'no', 'longer', 'necessary,', 'and', 'secretly', 'to', 'take']">
-			<rdg wit="f1818">if he should appear lukewarm; for he knew that he was still in the
-				power of his deliverer, if he should choose to betray &lt;pb xml:id="F1818_v2_096"
-				n="092"/&gt;him to the Italian state which they inhabited. He revolved a thousand
-				plans by which he should be enabled to prolong the deceit until it might be no
-				longer necessary, and secretly to take</rdg>
-			<rdg wit="f1823">if he should appear lukewarm; for he knew that he was still in the
-				power of his deliverer, if he should choose to betray &lt;pb xml:id="F1823_v2_297"
-				n="24"/&gt;him to the Italian state which they inhabited. He revolved a thousand
-				plans by which he should be enabled to prolong the deceit until it might be no
-				longer necessary, and secretly to take</rdg>
-			<rdg wit="fThomas">if he should appear lukewarm; for he knew that he was still in the
-				power of his deliverer, if he should choose to betray &lt;pb xml:id="F1818_v2_096"
-				n="092"/&gt;him to the Italian state which they inhabited. He revolved a thousand
-				plans by which he should be enabled to prolong the deceit until it might be no
-				longer necessary, and secretly to take</rdg>
-			<rdg wit="f1831">if he should appear lukewarm; for he knew that he was still in the
-				power of his deliverer, if he should choose to betray him to the Italian state which
-				they inhabited. He revolved a thousand plans by which he should be enabled to
-				prolong the deceit until it might be no longer necessary, and secretly to take</rdg>
+				he had formed far other plans. He loathed the idea that</rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -2280,13 +2281,71 @@
 	</app>
 	<app>
 		<rdgGrp n="['']">
-			<rdg wit="fMS">&lt;sga-add eID="c57-0033__main__d4e5480"/&gt;</rdg>
+			<rdg wit="fMS">&lt;sga-add eID="c57-0033__main__d4e5480"/&gt;&lt;mod
+				eID="c57-0033__main__d4e5475"/&gt;</rdg>
 		</rdgGrp>
-		<rdgGrp n="['with', 'him', 'when', 'he', 'departed.', 'his', 'plans', 'were']">
-			<rdg wit="f1818">with him when he departed. His plans were</rdg>
-			<rdg wit="f1823">with him when he departed. His plans were</rdg>
-			<rdg wit="fThomas">with him when he departed. His plans were</rdg>
-			<rdg wit="f1831">with him when he departed. His plans were</rdg>
+		<rdgGrp
+			n="['should', 'be', 'united', 'to', 'a', 'christian;', 'but', 'he', 'feared', 'the', 'resentment', 'of']">
+			<rdg wit="f1818">should be united to a Christian; but he feared the resentment of</rdg>
+			<rdg wit="f1823">should be united to a Christian; but he feared the resentment of</rdg>
+			<rdg wit="fThomas">should be united to a Christian; but he feared the resentment
+				of</rdg>
+			<rdg wit="f1831">should be united to a Christian; but he feared the resentment of</rdg>
+		</rdgGrp>
+	</app>
+	<app>
+		<rdgGrp n="['felix']">
+			<rdg wit="f1818">Felix</rdg>
+			<rdg wit="fThomas">Felix</rdg>
+		</rdgGrp>
+		<rdgGrp n="['felix,']">
+			<rdg wit="f1823">Felix,</rdg>
+			<rdg wit="f1831">Felix,</rdg>
+		</rdgGrp>
+	</app>
+	<app>
+		<rdgGrp
+			n="['if', 'he', 'should', 'appear', 'lukewarm;', 'for', 'he', 'knew', 'that', 'he', 'was', 'still', 'in', 'the', 'power', 'of', 'his', 'deliverer,', 'if', 'he', 'should', 'choose', 'to', 'betray', 'him', 'to', 'the', 'italian', 'state', 'which', 'they', 'inhabited.', 'he', 'revolved', 'a', 'thousand', 'plans', 'by', 'which', 'he', 'should', 'be', 'enabled', 'to', 'prolong', 'the', 'deceit', 'until', 'it', 'might', 'be', 'no', 'longer', 'necessary,', 'and', 'secretly']">
+			<rdg wit="f1818">if he should appear lukewarm; for he knew that he was still in the
+				power of his deliverer, if he should choose to betray &lt;pb xml:id="F1818_v2_096"
+				n="092"/&gt;him to the Italian state which they inhabited. He revolved a thousand
+				plans by which he should be enabled to prolong the deceit until it might be no
+				longer necessary, and secretly</rdg>
+			<rdg wit="f1823">if he should appear lukewarm; for he knew that he was still in the
+				power of his deliverer, if he should choose to betray &lt;pb xml:id="F1823_v2_297"
+				n="24"/&gt;him to the Italian state which they inhabited. He revolved a thousand
+				plans by which he should be enabled to prolong the deceit until it might be no
+				longer necessary, and secretly</rdg>
+			<rdg wit="fThomas">if he should appear lukewarm; for he knew that he was still in the
+				power of his deliverer, if he should choose to betray &lt;pb xml:id="F1818_v2_096"
+				n="092"/&gt;him to the Italian state which they inhabited. He revolved a thousand
+				plans by which he should be enabled to prolong the deceit until it might be no
+				longer necessary, and secretly</rdg>
+			<rdg wit="f1831">if he should appear lukewarm; for he knew that he was still in the
+				power of his deliverer, if he should choose to betray him to the Italian state which
+				they inhabited. He revolved a thousand plans by which he should be enabled to
+				prolong the deceit until it might be no longer necessary, and secretly</rdg>
+		</rdgGrp>
+	</app>
+	<app>
+		<rdgGrp n="['to']">
+			<rdg wit="f1818">to</rdg>
+			<rdg wit="f1823">to</rdg>
+			<rdg wit="fThomas">to</rdg>
+			<rdg wit="f1831">to</rdg>
+			<rdg wit="fMS">to</rdg>
+		</rdgGrp>
+	</app>
+	<app>
+		<rdgGrp
+			n="['take', 'his', 'daughter', 'with', 'him', 'when', 'he', 'departed.', 'his', 'plans', 'were']">
+			<rdg wit="f1818">take his daughter with him when he departed. His plans were</rdg>
+			<rdg wit="f1823">take his daughter with him when he departed. His plans were</rdg>
+			<rdg wit="fThomas">take his daughter with him when he departed. His plans were</rdg>
+			<rdg wit="f1831">take his daughter with him when he departed. His plans were</rdg>
+		</rdgGrp>
+		<rdgGrp n="['think']">
+			<rdg wit="fMS">think</rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -2298,44 +2357,59 @@
 	</app>
 	<app>
 		<rdgGrp
-			n="['facilitated', 'by', 'the', 'news', 'which', 'arrived', 'from', 'paris.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&#34;the', 'government', 'of', 'france', 'were', 'greatly', 'enraged', 'at', 'the', 'escape', 'of', 'their', 'victim,', 'and', 'spared', 'no', 'pains', 'to', 'detect', 'and', 'punish', 'his', 'deliverer.', 'the', 'plot', 'of', 'felix', 'was', 'quickly', 'discovered,', 'and', 'de', 'lacey', 'and', 'agatha', 'were', 'thrown', 'into', 'prison.', 'the', 'news', 'reached', 'felix,', 'and', 'roused', 'him', 'from', 'his', 'dream', 'of', 'pleasure.', 'his', 'blind', 'and', 'aged', 'father,', 'and', 'his', 'gentle', 'sister,', 'lay', 'in', 'a', 'noisome', 'dungeon,', 'while', 'he', 'enjoyed', 'the', 'free', 'air,', 'and', 'the', 'society', 'of', 'her', 'whom', 'he', 'loved.', 'this', 'idea', 'was', 'torture', 'to', 'him.', 'he', 'quickly', 'arranged', 'with', 'the']">
+			n="['facilitated', 'by', 'the', 'news', 'which', 'arrived', 'from', 'paris.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&#34;the', 'government', 'of', 'france', 'were', 'greatly', 'enraged', 'at', 'the', 'escape', 'of', 'their', 'victim,', 'and', 'spared']">
 			<rdg wit="f1818">facilitated by the news which arrived from Paris. &lt;p
 				eID="novel1_letter4_chapter13_div4_div14_p12"/&gt; &lt;p
 				sID="novel1_letter4_chapter13_div4_div14_p13"/&gt; “The government of France were
-				greatly enraged at the escape of their victim, and spared no pains to detect and
-				punish his deliverer. The plot of Felix was quickly discovered, and De Lacey and
-				Agatha were thrown into prison. The news reached Felix, and roused him from his
-				dream of pleasure. His blind and aged father, and his gentle sister, lay in a
-				noisome dungeon, while he enjoyed the free air, and the society of her whom he
-				loved. This idea was torture to him. He quickly arranged with the</rdg>
+				greatly enraged at the escape of their victim, and spared</rdg>
 			<rdg wit="f1823">facilitated by the news which arrived from Paris. &lt;p
 				eID="novel1_letter4_chapter13_div4_div14_p12"/&gt; &lt;p
 				sID="novel1_letter4_chapter13_div4_div14_p13"/&gt; “The government of France were
-				greatly enraged at the escape of their victim, and spared no pains to detect and
-				punish his deliverer. The plot of Felix was quickly discovered, and De Lacey and
-				Agatha were thrown into prison. The news reached Felix, and roused him from his
-				dream of pleasure. His blind and aged father, and his gentle sister, lay in a
-				noisome dungeon, while he enjoyed the free air, and the society of her whom he
-				loved. This idea was torture to him. He quickly arranged with the</rdg>
+				greatly enraged at the escape of their victim, and spared</rdg>
 			<rdg wit="fThomas">facilitated by the news which arrived from Paris. &lt;p
 				eID="novel1_letter4_chapter13_div4_div14_p12"/&gt; &lt;p
 				sID="novel1_letter4_chapter13_div4_div14_p13"/&gt; “The government of France were
-				greatly enraged at the escape of their victim, and spared no pains to detect and
-				punish his deliverer. The plot of Felix was quickly discovered, and De Lacey and
-				Agatha were thrown into prison. The news reached Felix, and roused him from his
-				dream of pleasure. His blind and aged father, and his gentle sister, lay in a
-				noisome dungeon, while he enjoyed the free air, and the society of her whom he
-				loved. This idea was torture to him. He quickly arranged with the</rdg>
+				greatly enraged at the escape of their victim, and spared</rdg>
 			<rdg wit="f1831">facilitated by the news which arrived from Paris. &lt;p
 				eID="novel1_letter4_chapter14_div4_div14_p12"/&gt; &lt;p
 				sID="novel1_letter4_chapter14_div4_div14_p13"/&gt; “The government of France were
-				greatly enraged at the escape of their victim, and spared no pains to detect and
-				punish his deliverer. The plot of Felix was quickly discovered, and De Lacey and
-				Agatha were thrown into prison. The news reached Felix, and roused him from his
-				dream of pleasure. His blind and aged father, and his gentle sister, lay in a
-				noisome dungeon, while he enjoyed the free air, and the society of her whom he
-				loved. This idea was &lt;pb xml:id="F1831_v_124" n="108"/&gt;torture to him. He
-				quickly arranged with the</rdg>
+				greatly enraged at the escape of their victim, and spared</rdg>
+		</rdgGrp>
+	</app>
+	<app>
+		<rdgGrp n="['no']">
+			<rdg wit="f1818">no</rdg>
+			<rdg wit="f1823">no</rdg>
+			<rdg wit="fThomas">no</rdg>
+			<rdg wit="f1831">no</rdg>
+			<rdg wit="fMS">no</rdg>
+		</rdgGrp>
+	</app>
+	<app>
+		<rdgGrp
+			n="['pains', 'to', 'detect', 'and', 'punish', 'his', 'deliverer.', 'the', 'plot', 'of', 'felix', 'was', 'quickly', 'discovered,', 'and', 'de', 'lacey', 'and', 'agatha', 'were', 'thrown', 'into', 'prison.', 'the', 'news', 'reached', 'felix,', 'and', 'roused', 'him', 'from', 'his', 'dream', 'of', 'pleasure.', 'his', 'blind', 'and', 'aged', 'father,', 'and', 'his', 'gentle', 'sister,', 'lay', 'in', 'a', 'noisome', 'dungeon,', 'while', 'he', 'enjoyed', 'the', 'free', 'air,', 'and', 'the', 'society', 'of', 'her', 'whom', 'he', 'loved.', 'this', 'idea', 'was', 'torture', 'to', 'him.', 'he', 'quickly', 'arranged', 'with', 'the']">
+			<rdg wit="f1818">pains to detect and punish his deliverer. The plot of Felix was quickly
+				discovered, and De Lacey and Agatha were thrown into prison. The news reached Felix,
+				and roused him from his dream of pleasure. His blind and aged father, and his gentle
+				sister, lay in a noisome dungeon, while he enjoyed the free air, and the society of
+				her whom he loved. This idea was torture to him. He quickly arranged with the</rdg>
+			<rdg wit="f1823">pains to detect and punish his deliverer. The plot of Felix was quickly
+				discovered, and De Lacey and Agatha were thrown into prison. The news reached Felix,
+				and roused him from his dream of pleasure. His blind and aged father, and his gentle
+				sister, lay in a noisome dungeon, while he enjoyed the free air, and the society of
+				her whom he loved. This idea was torture to him. He quickly arranged with the</rdg>
+			<rdg wit="fThomas">pains to detect and punish his deliverer. The plot of Felix was
+				quickly discovered, and De Lacey and Agatha were thrown into prison. The news
+				reached Felix, and roused him from his dream of pleasure. His blind and aged father,
+				and his gentle sister, lay in a noisome dungeon, while he enjoyed the free air, and
+				the society of her whom he loved. This idea was torture to him. He quickly arranged
+				with the</rdg>
+			<rdg wit="f1831">pains to detect and punish his deliverer. The plot of Felix was quickly
+				discovered, and De Lacey and Agatha were thrown into prison. The news reached Felix,
+				and roused him from his dream of pleasure. His blind and aged father, and his gentle
+				sister, lay in a noisome dungeon, while he enjoyed the free air, and the society of
+				her whom he loved. This idea was &lt;pb xml:id="F1831_v_124" n="108"/&gt;torture to
+				him. He quickly arranged with the</rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -2527,44 +2601,71 @@
 	</app>
 	<app>
 		<rdgGrp
-			n="['gloried', 'in', 'it:', 'but', 'the', 'ingratitude', 'of', 'the', 'turk,', 'and', 'the', 'loss', 'of', 'his', 'beloved', 'safie,', 'were', 'misfortunes', 'more', 'bitter', 'and', 'irreparable.', 'the', 'arrival', 'of', 'the', 'arabian', 'now', 'infused', 'new', 'life', 'into', 'his', 'soul.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&#34;when', 'the', 'news', 'reached', 'leghorn,', 'that', 'felix', 'was', 'deprived', 'of', 'his', 'wealth', 'and', 'rank,', 'the', 'merchant', 'commanded', 'his', 'daughter']">
+			n="['gloried', 'in', 'it:', 'but', 'the', 'ingratitude', 'of', 'the', 'turk,', 'and', 'the', 'loss', 'of', 'his', 'beloved', 'safie,', 'were', 'misfortunes']">
 			<rdg wit="f1818">gloried in it: but the ingratitude of the Turk, and the loss of his
-				beloved Safie, were misfortunes more bitter and irreparable. The arrival of the
-				Arabian now infused new life into his soul. &lt;p
-				eID="novel1_letter4_chapter13_div4_div14_p16"/&gt; &lt;p
-				sID="novel1_letter4_chapter13_div4_div14_p17"/&gt; “When the news reached Leghorn,
-				that Felix was deprived of his wealth and rank, the merchant commanded his
-				daughter</rdg>
+				beloved Safie, were misfortunes</rdg>
 			<rdg wit="f1823">gloried in it: but the ingratitude of the Turk, and the loss of his
-				beloved Safie, were misfortunes more bitter and irreparable. The arrival of the
-				Arabian now infused new life into his soul. &lt;p
-				eID="novel1_letter4_chapter13_div4_div14_p16"/&gt; &lt;p
-				sID="novel1_letter4_chapter13_div4_div14_p17"/&gt; “When the news reached Leghorn,
-				that Felix was deprived of his wealth and rank, the merchant commanded his
-				daughter</rdg>
+				beloved Safie, were misfortunes</rdg>
 			<rdg wit="fThomas">gloried in it: but the ingratitude of the Turk, and the loss of his
-				beloved Safie, were misfortunes more bitter and irreparable. The arrival of the
-				Arabian now infused new life into his soul. &lt;p
-				eID="novel1_letter4_chapter13_div4_div14_p15"/&gt; &lt;p
-				sID="novel1_letter4_chapter13_div4_div14_p16"/&gt; “When the news reached Leghorn,
-				that Felix was deprived of his wealth and rank, the merchant commanded his
-				daughter</rdg>
+				beloved Safie, were misfortunes</rdg>
 			<rdg wit="f1831">gloried in it: but the ingratitude of the Turk, and the loss of his
-				beloved Safie, were misfortunes more bitter and irreparable. The arrival of the
-				Arabian now infused new life into his soul. &lt;p
-				eID="novel1_letter4_chapter14_div4_div14_p16"/&gt; &lt;p
-				sID="novel1_letter4_chapter14_div4_div14_p17"/&gt; “When the news reached Leghorn,
-				that Felix was deprived of his wealth and rank, the merchant commanded his
-				daughter</rdg>
+				beloved Safie, were misfortunes</rdg>
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['to', 'think', 'no', 'more', 'of']">
-			<rdg wit="f1818">to think no more of</rdg>
-			<rdg wit="f1823">to think no more of</rdg>
-			<rdg wit="fThomas">to think no more of</rdg>
-			<rdg wit="f1831">to think no more of</rdg>
-			<rdg wit="fMS">to think no more of</rdg>
+		<rdgGrp n="['more']">
+			<rdg wit="f1818">more</rdg>
+			<rdg wit="f1823">more</rdg>
+			<rdg wit="fThomas">more</rdg>
+			<rdg wit="f1831">more</rdg>
+			<rdg wit="fMS">more</rdg>
+		</rdgGrp>
+	</app>
+	<app>
+		<rdgGrp
+			n="['bitter', 'and', 'irreparable.', 'the', 'arrival', 'of', 'the', 'arabian', 'now', 'infused', 'new', 'life', 'into', 'his', 'soul.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&#34;when', 'the', 'news', 'reached', 'leghorn,', 'that', 'felix', 'was', 'deprived']">
+			<rdg wit="f1818">bitter and irreparable. The arrival of the Arabian now infused new life
+				into his soul. &lt;p eID="novel1_letter4_chapter13_div4_div14_p16"/&gt; &lt;p
+				sID="novel1_letter4_chapter13_div4_div14_p17"/&gt; “When the news reached Leghorn,
+				that Felix was deprived</rdg>
+			<rdg wit="f1823">bitter and irreparable. The arrival of the Arabian now infused new life
+				into his soul. &lt;p eID="novel1_letter4_chapter13_div4_div14_p16"/&gt; &lt;p
+				sID="novel1_letter4_chapter13_div4_div14_p17"/&gt; “When the news reached Leghorn,
+				that Felix was deprived</rdg>
+			<rdg wit="fThomas">bitter and irreparable. The arrival of the Arabian now infused new
+				life into his soul. &lt;p eID="novel1_letter4_chapter13_div4_div14_p15"/&gt; &lt;p
+				sID="novel1_letter4_chapter13_div4_div14_p16"/&gt; “When the news reached Leghorn,
+				that Felix was deprived</rdg>
+			<rdg wit="f1831">bitter and irreparable. The arrival of the Arabian now infused new life
+				into his soul. &lt;p eID="novel1_letter4_chapter14_div4_div14_p16"/&gt; &lt;p
+				sID="novel1_letter4_chapter14_div4_div14_p17"/&gt; “When the news reached Leghorn,
+				that Felix was deprived</rdg>
+		</rdgGrp>
+	</app>
+	<app>
+		<rdgGrp n="['of']">
+			<rdg wit="f1818">of</rdg>
+			<rdg wit="f1823">of</rdg>
+			<rdg wit="fThomas">of</rdg>
+			<rdg wit="f1831">of</rdg>
+			<rdg wit="fMS">of</rdg>
+		</rdgGrp>
+	</app>
+	<app>
+		<rdgGrp n="['', '&lt;delstart/&gt;him&lt;delend/&gt;']">
+			<rdg wit="fMS">&lt;mod sID="c57-0033__main__d4e5484"/&gt; &lt;del rend="strikethrough"
+				xml:id="c57-0033__main__d4e5486"&gt;him&lt;/del&gt;</rdg>
+		</rdgGrp>
+		<rdgGrp
+			n="['his', 'wealth', 'and', 'rank,', 'the', 'merchant', 'commanded', 'his', 'daughter', 'to', 'think', 'no', 'more', 'of']">
+			<rdg wit="f1818">his wealth and rank, the merchant commanded his daughter to think no
+				more of</rdg>
+			<rdg wit="f1823">his wealth and rank, the merchant commanded his daughter to think no
+				more of</rdg>
+			<rdg wit="fThomas">his wealth and rank, the merchant commanded his daughter to think no
+				more of</rdg>
+			<rdg wit="f1831">his wealth and rank, the merchant commanded his daughter to think no
+				more of</rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -2573,17 +2674,14 @@
 			<rdg wit="f1823">her</rdg>
 			<rdg wit="fThomas">her</rdg>
 			<rdg wit="f1831">her</rdg>
-		</rdgGrp>
-		<rdgGrp n="['&lt;delstart/&gt;him&lt;delend/&gt;', 'her']">
-			<rdg wit="fMS">&lt;del rend="strikethrough"
-				xml:id="c57-0033__main__d4e5486"&gt;him&lt;/del&gt; &lt;sga-add place="superlinear"
+			<rdg wit="fMS">&lt;sga-add place="superlinear"
 				sID="c57-0033__main__d4e5489"/&gt;her</rdg>
 		</rdgGrp>
 	</app>
-
 	<app>
 		<rdgGrp n="['lover', '']">
-			<rdg wit="fMS">lover &lt;sga-add eID="c57-0033__main__d4e5489"/&gt;</rdg>
+			<rdg wit="fMS">lover &lt;sga-add eID="c57-0033__main__d4e5489"/&gt;&lt;mod
+				eID="c57-0033__main__d4e5484"/&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp n="['lover,']">
 			<rdg wit="f1818">&lt;pb xml:id="F1818_v2_099" n="095"/&gt;lover,</rdg>
@@ -2890,8 +2988,8 @@
 			<rdg wit="f1831">should</rdg>
 		</rdgGrp>
 		<rdgGrp
-			n="['&lt;delstart/&gt;would&lt;delend/&gt;', '', '&lt;delstart/&gt;was&lt;delend/&gt;', 'should']">
-			<rdg wit="fMS">&lt;del rend="strikethrough"
+			n="['', '&lt;delstart/&gt;would&lt;delend/&gt;', '', '&lt;delstart/&gt;was&lt;delend/&gt;', 'should']">
+			<rdg wit="fMS">&lt;mod sID="c57-0033__main__d4e5536"/&gt; &lt;del rend="strikethrough"
 				xml:id="c57-0033__main__d4e5538"&gt;would&lt;/del&gt; &lt;sga-add
 				place="superlinear" sID="c57-0033__main__d4e5541"/&gt; &lt;del rend="strikethrough"
 				xml:id="c57-0033__main__d4e5543"&gt;was&lt;/del&gt; should</rdg>
@@ -2905,9 +3003,10 @@
 			<rdg wit="fThomas">speedily be delivered</rdg>
 			<rdg wit="f1831">speedily be delivered</rdg>
 		</rdgGrp>
-		<rdgGrp n="['', '', 'speedily', 'be', 'delivered']">
+		<rdgGrp n="['', '', '', 'speedily', 'be', 'delivered']">
 			<rdg wit="fMS">&lt;sga-add eID="c57-0033__main__d4e5541"/&gt; &lt;mdel&gt;b&lt;/mdel&gt;
-				speedily &lt;lb n="c57-0033__main__25"/&gt;be delivered</rdg>
+				&lt;mod eID="c57-0033__main__d4e5536"/&gt; speedily &lt;lb
+				n="c57-0033__main__25"/&gt;be delivered</rdg>
 		</rdgGrp>
 	</app>
 
@@ -2919,8 +3018,9 @@
 			<rdg wit="f1831">up</rdg>
 		</rdgGrp>
 		<rdgGrp n="['', '', 'up']">
-			<rdg wit="fMS">&lt;sga-add place="sublinear" sID="c57-0033__main__d4e5554"/&gt;
-				&lt;metamark function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
+			<rdg wit="fMS">&lt;mod sID="c57-0033__main__d4e5552"/&gt;&lt;sga-add place="sublinear"
+				sID="c57-0033__main__d4e5554"/&gt; &lt;metamark
+				function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
 				eID="c57-0033__main__d4e5554"/&gt;&lt;sga-add hand="#pbs" place="superlinear"
 				sID="c57-0033__main__d4e5560"/&gt;up</rdg>
 		</rdgGrp>
@@ -2928,15 +3028,17 @@
 
 	<app>
 		<rdgGrp
-			n="['', 'to the french government–', 'he', 'had', 'just', 'heard', 'of', 'a', 'small', 'vessel', 'bound', 'for', 'constantinople', 'which', 'he', 'had', 'consequently', 'hired', 'a', 'vessel', 'to', 'convey', 'him', 'to', '&lt;delstart/&gt;can&lt;delend/&gt;', 'constantinople', '']">
-			<rdg wit="fMS">&lt;sga-add eID="c57-0033__main__d4e5560"/&gt; &lt;longToken&gt;to the
-				French Government–&lt;/longToken&gt; &lt;lb n="c57-0033__main__26"/&gt;&lt;delSpan
+			n="['', 'to the french government–', 'he', 'had', 'just', 'heard', 'of', 'a', 'small', 'vessel', 'bound', 'for', 'constantinople', 'which', 'he', 'had', 'consequently', 'hired', 'a', 'vessel', 'to', 'convey', 'him', 'to', '&lt;delstart/&gt;can&lt;delend/&gt;', 'constantinople', '', '']">
+			<rdg wit="fMS">&lt;sga-add eID="c57-0033__main__d4e5560"/&gt;&lt;mod
+				eID="c57-0033__main__d4e5552"/&gt; &lt;longToken&gt;to the French
+				Government–&lt;/longToken&gt; &lt;lb n="c57-0033__main__26"/&gt;&lt;delSpan
 				rend="strikethrough" spanTo="#c57-0033.04"/&gt;He had just heard of a small vessel
 				&lt;lb n="c57-0033__main__27"/&gt;bound for Constantinople which &lt;anchor
 				xml:id="c57-0033.04"/&gt;He had &lt;lb n="c57-0033__main__28"/&gt;consequently hired
 				a vessel to convey him &lt;lb n="c57-0034__main__1"/&gt;to &lt;del
 				rend="strikethrough" xml:id="c57-0034__main__d4e5585"&gt;Can&lt;/del&gt;
-				Constantinople &lt;mdel&gt;in&lt;/mdel&gt;</rdg>
+				Constantinople &lt;mod sID="c57-0034__main__d4e5588"/&gt;
+				&lt;mdel&gt;in&lt;/mdel&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp n="['to the french government; ']">
 			<rdg wit="f1818">&lt;longToken&gt;to the French government; &lt;/longToken&gt;</rdg>
@@ -2975,8 +3077,9 @@
 			<rdg wit="f1823">which city </rdg>
 			<rdg wit="fThomas">which city </rdg>
 			<rdg wit="f1831">which city </rdg>
-			<rdg wit="fMS">&lt;sga-add eID="c57-0034__main__d4e5592"/&gt;which &lt;sga-add
-				hand="#pbs" place="superlinear" sID="c57-0034__main__d4e5596"/&gt;city</rdg>
+			<rdg wit="fMS">&lt;sga-add eID="c57-0034__main__d4e5592"/&gt;&lt;mod
+				eID="c57-0034__main__d4e5588"/&gt;which &lt;sga-add hand="#pbs" place="superlinear"
+				sID="c57-0034__main__d4e5596"/&gt;city</rdg>
 		</rdgGrp>
 	</app>
 
@@ -3511,10 +3614,10 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['', '20', '']">
-			<rdg wit="fMS">&lt;mdel&gt;50&lt;/mdel&gt; &lt;sga-add place="superlinear"
-				sID="c57-0034__main__d4e5710"/&gt;20 &lt;sga-add
-				eID="c57-0034__main__d4e5710"/&gt;</rdg>
+		<rdgGrp n="['', '', '20', '']">
+			<rdg wit="fMS">&lt;mod sID="c57-0034__main__d4e5706"/&gt; &lt;mdel&gt;50&lt;/mdel&gt;
+				&lt;sga-add place="superlinear" sID="c57-0034__main__d4e5710"/&gt;20 &lt;sga-add
+				eID="c57-0034__main__d4e5710"/&gt;&lt;mod eID="c57-0034__main__d4e5706"/&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp n="['twenty']">
 			<rdg wit="f1818">twenty</rdg>
@@ -3572,8 +3675,9 @@
 			<rdg wit="f1831">dangerously</rdg>
 		</rdgGrp>
 		<rdgGrp n="['', '', 'dangerously']">
-			<rdg wit="fMS">&lt;sga-add place="sublinear" sID="c57-0034__main__d4e5720"/&gt;
-				&lt;metamark function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
+			<rdg wit="fMS">&lt;mod sID="c57-0034__main__d4e5718"/&gt;&lt;sga-add place="sublinear"
+				sID="c57-0034__main__d4e5720"/&gt; &lt;metamark
+				function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
 				eID="c57-0034__main__d4e5720"/&gt;&lt;sga-add place="superlinear"
 				sID="c57-0034__main__d4e5726"/&gt;dangerously</rdg>
 		</rdgGrp>
@@ -3581,9 +3685,9 @@
 
 	<app>
 		<rdgGrp n="['', 'ill', '&lt;delstart/&gt;and she was retarded wh&lt;delend/&gt;']">
-			<rdg wit="fMS">&lt;sga-add eID="c57-0034__main__d4e5726"/&gt; ill &lt;del
-				rend="strikethrough" xml:id="c57-0034__main__d4e5730"&gt;and she was retarded
-				wh&lt;/del&gt;</rdg>
+			<rdg wit="fMS">&lt;sga-add eID="c57-0034__main__d4e5726"/&gt;&lt;mod
+				eID="c57-0034__main__d4e5718"/&gt; ill &lt;del rend="strikethrough"
+				xml:id="c57-0034__main__d4e5730"&gt;and she was retarded wh&lt;/del&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp n="['ill.']">
 			<rdg wit="f1818">ill.</rdg>
@@ -3653,7 +3757,7 @@
 			<rdg wit="f1823">and</rdg>
 			<rdg wit="fThomas">and</rdg>
 			<rdg wit="f1831">and</rdg>
-			<rdg wit="fMS">&amp;</rdg>
+			<rdg wit="fMS">&amp;&lt;mod sID="c57-0034__main__d4e5741"/&gt;</rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -3667,7 +3771,8 @@
 			<rdg wit="fMS">&lt;del rend="strikethrough"
 				xml:id="c57-0034__main__d4e5743"&gt;Safie&lt;/del&gt; &lt;sga-add
 				place="superlinear" sID="c57-0034__main__d4e5746"/&gt;the Arabian &lt;sga-add
-				eID="c57-0034__main__d4e5746"/&gt;&lt;lb n="c57-0034__main__28"/&gt;was left</rdg>
+				eID="c57-0034__main__d4e5746"/&gt;&lt;mod eID="c57-0034__main__d4e5741"/&gt;&lt;lb
+				n="c57-0034__main__28"/&gt;was left</rdg>
 		</rdgGrp>
 	</app>
 
@@ -3789,7 +3894,8 @@
 			<rdg wit="f1831">had</rdg>
 		</rdgGrp>
 		<rdgGrp n="['', '&lt;delstart/&gt;before her death&lt;delend/&gt;', 'had']">
-			<rdg wit="fMS">&lt;lb n="c57-0035__main__5"/&gt; &lt;del rend="strikethrough"
+			<rdg wit="fMS">&lt;lb n="c57-0035__main__5"/&gt;&lt;mod
+				sID="c57-0035__main__d4e5794"/&gt; &lt;del rend="strikethrough"
 				xml:id="c57-0035__main__d4e5796"&gt;before her death&lt;/del&gt; &lt;sga-add
 				place="superlinear" sID="c57-0035__main__d4e5799"/&gt;had</rdg>
 		</rdgGrp>
@@ -3802,8 +3908,9 @@
 			<rdg wit="f1823">mentioned the name of the spot for which they were </rdg>
 			<rdg wit="fThomas">mentioned the name of the spot for which they were </rdg>
 			<rdg wit="f1831">mentioned the name of the spot for which they were </rdg>
-			<rdg wit="fMS">&lt;sga-add eID="c57-0035__main__d4e5799"/&gt;mentioned the name of the
-				&lt;lb n="c57-0035__main__6"/&gt;spot for which they were</rdg>
+			<rdg wit="fMS">&lt;sga-add eID="c57-0035__main__d4e5799"/&gt;&lt;mod
+				eID="c57-0035__main__d4e5794"/&gt;mentioned the name of the &lt;lb
+				n="c57-0035__main__6"/&gt;spot for which they were</rdg>
 		</rdgGrp>
 	</app>
 
@@ -3874,27 +3981,32 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['&lt;p-end/&gt;']">
-			<rdg wit="f1818">&lt;p eID="novel1_letter4_chapter13_div4_div14_p20"/&gt;</rdg>
-			<rdg wit="f1823">&lt;p eID="novel1_letter4_chapter13_div4_div14_p20"/&gt;</rdg>
-			<rdg wit="fThomas">&lt;p eID="novel1_letter4_chapter13_div4_div14_p18"/&gt;</rdg>
-			<rdg wit="f1831">&lt;p eID="novel1_letter4_chapter14_div4_div14_p20"/&gt;</rdg>
+		<rdgGrp n="['&lt;p-end/&gt;', '']">
+			<rdg wit="f1818">&lt;p eID="novel1_letter4_chapter13_div4_div14_p20"/&gt; &lt;milestone
+				unit="chapter" type="end" n="13"/&gt;</rdg>
+			<rdg wit="f1823">&lt;p eID="novel1_letter4_chapter13_div4_div14_p20"/&gt; &lt;milestone
+				unit="chapter" type="end" n="13"/&gt;</rdg>
+			<rdg wit="fThomas">&lt;p eID="novel1_letter4_chapter13_div4_div14_p18"/&gt;
+				&lt;milestone unit="chapter" type="end" n="13"/&gt;</rdg>
+			<rdg wit="f1831">&lt;p eID="novel1_letter4_chapter14_div4_div14_p20"/&gt; &lt;milestone
+				unit="chapter" type="end" n="14"/&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp
 			n="['having overcome many difficulties succeeded at length in joining her lover in his retreat ']">
 			<rdg wit="fMS">&lt;longToken&gt;&lt;delSpan rend="strikethrough"
 				spanTo="#c57-0037.01"/&gt;having overcome many difficulties succeeded &lt;lb
-				n="c57-0037__main__2"/&gt;at length in joining her lover in his retreat</rdg>
+				n="c57-0037__main__2"/&gt;at length in joining her lover in his retreat &lt;anchor
+				xml:id="c57-0037.01"/&gt;&lt;/longToken&gt;</rdg>
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['', '']">
-			<rdg wit="f1818">&lt;milestone unit="chapter" type="end" n="13"/&gt;</rdg>
-			<rdg wit="f1823">&lt;milestone unit="chapter" type="end" n="13"/&gt;</rdg>
-			<rdg wit="fThomas">&lt;milestone unit="chapter" type="end" n="13"/&gt;</rdg>
-			<rdg wit="f1831">&lt;milestone unit="chapter" type="end" n="14"/&gt;</rdg>
-			<rdg wit="fMS">&lt;anchor xml:id="c57-0037.01"/&gt;&lt;/longToken&gt;</rdg>
+		<rdgGrp n="['']">
+			<rdg wit="f1818"/>
+			<rdg wit="f1823"/>
+			<rdg wit="fThomas"/>
+			<rdg wit="f1831"/>
+			<rdg wit="fMS"/>
 		</rdgGrp>
 	</app>
 </cx:apparatus>
-<!-- 2023-03-16 04:45:53.915302 -->
+<!-- 2023-03-16 18:19:21.532540 -->

--- a/collationChunks/C20/output/Collation_C20-complete-prePythonChange.xml
+++ b/collationChunks/C20/output/Collation_C20-complete-prePythonChange.xml
@@ -72,14 +72,13 @@
 			<rdg wit="f1831">learned</rdg>
 		</rdgGrp>
 		<rdgGrp
-			n="['&lt;delstart/&gt;became informed&lt;delend/&gt;', '', '&lt;delstart/&gt; of th &lt;delend/&gt;', '', '&lt;mdel&gt;of&lt;/mdel&gt;', '', '', 'learned']">
+			n="['&lt;delstart/&gt;became informed&lt;delend/&gt;', '', '&lt;delstart/&gt; of th &lt;delend/&gt;', '', '', '', '', 'learned']">
 			<rdg wit="fMS">&lt;del next="#c57-0031.02" rend="strikethrough"
 				xml:id="c57-0031__main__d4e4832"&gt;became informed&lt;/del&gt; &lt;lb
 				n="c57-0031__main__3"/&gt;&lt;anchor xml:id="c57-0031.03"/&gt;&lt;lb
 				n="c57-0031__left_margin__1"/&gt; &lt;del rend="strikethrough"
 				xml:id="c57-0031__left_margin__d4e4843"&gt; of th &lt;/del&gt; &lt;anchor
-				xml:id="c57-0031.01"/&gt;&lt;mod sID="c57-0031__main__d4e4849"/&gt;
-				&lt;mdel&gt;of&lt;/mdel&gt; &lt;sga-add place="sublinear"
+				xml:id="c57-0031.01"/&gt; &lt;mdel&gt;of&lt;/mdel&gt; &lt;sga-add place="sublinear"
 				sID="c57-0031__main__d4e4853"/&gt; &lt;metamark
 				function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
 				eID="c57-0031__main__d4e4853"/&gt;&lt;sga-add place="superlinear"
@@ -93,8 +92,8 @@
 			<rdg wit="f1823">the history of my friends. It was one </rdg>
 			<rdg wit="fThomas">the history of my friends. It was one </rdg>
 			<rdg wit="f1831">the history of my friends. It was one </rdg>
-			<rdg wit="fMS">&lt;sga-add eID="c57-0031__main__d4e4859"/&gt;&lt;mod
-				eID="c57-0031__main__d4e4849"/&gt;the history of my friends. It was one</rdg>
+			<rdg wit="fMS">&lt;sga-add eID="c57-0031__main__d4e4859"/&gt;the history of my friends.
+				It was one</rdg>
 		</rdgGrp>
 	</app>
 
@@ -119,14 +118,11 @@
 
 	<app>
 		<rdgGrp n="['on']">
-			<rdg wit="f1818">on</rdg>
-			<rdg wit="f1823">on</rdg>
-			<rdg wit="fThomas">on</rdg>
-			<rdg wit="f1831">on</rdg>
-		</rdgGrp>
-		<rdgGrp n="['', '&lt;mdel&gt;in&lt;/mdel&gt;', 'on']">
-			<rdg wit="fMS">&lt;mod sID="c57-0031__main__d4e4881"/&gt; &lt;mdel&gt;in&lt;/mdel&gt;
-				&lt;sga-add hand="#pbs" place="superlinear"
+			<rdg wit="f1818">on </rdg>
+			<rdg wit="f1823">on </rdg>
+			<rdg wit="fThomas">on </rdg>
+			<rdg wit="f1831">on </rdg>
+			<rdg wit="fMS">&lt;mdel&gt;in&lt;/mdel&gt;&lt;sga-add hand="#pbs" place="superlinear"
 				sID="c57-0031__main__d4e4885"/&gt;on</rdg>
 		</rdgGrp>
 	</app>
@@ -137,8 +133,7 @@
 			<rdg wit="f1823">my </rdg>
 			<rdg wit="fThomas">my </rdg>
 			<rdg wit="f1831">my </rdg>
-			<rdg wit="fMS">&lt;sga-add eID="c57-0031__main__d4e4885"/&gt;&lt;mod
-				eID="c57-0031__main__d4e4881"/&gt;my</rdg>
+			<rdg wit="fMS">&lt;sga-add eID="c57-0031__main__d4e4885"/&gt;my</rdg>
 		</rdgGrp>
 	</app>
 
@@ -352,16 +347,13 @@
 
 	<app>
 		<rdgGrp n="['in', 'the', 'service', 'of', 'his']">
-			<rdg wit="f1818">in the ser&lt;pb xml:id="F1818_v2_089" n="085"/&gt;vice of his</rdg>
-			<rdg wit="f1823">in the ser&lt;pb xml:id="F1823_v2_290" n="17"/&gt;vice of his</rdg>
-			<rdg wit="fThomas">in the ser&lt;pb xml:id="F1818_v2_089" n="085"/&gt;vice of his</rdg>
-			<rdg wit="f1831">in the service of his</rdg>
-		</rdgGrp>
-		<rdgGrp n="['', '&lt;mdel&gt;t&lt;/mdel&gt;', 'in', 'the', 'service', 'of', 'his']">
-			<rdg wit="fMS">&lt;mod sID="c57-0031__main__d4e4939"/&gt; &lt;mdel&gt;t&lt;/mdel&gt;
-				&lt;sga-add place="intralinear" sID="c57-0031__main__d4e4943"/&gt;i&lt;sga-add
-				eID="c57-0031__main__d4e4943"/&gt;&lt;mod eID="c57-0031__main__d4e4939"/&gt;n the
-				service of his</rdg>
+			<rdg wit="f1818">in the ser&lt;pb xml:id="F1818_v2_089" n="085"/&gt;vice of his </rdg>
+			<rdg wit="f1823">in the ser&lt;pb xml:id="F1823_v2_290" n="17"/&gt;vice of his </rdg>
+			<rdg wit="fThomas">in the ser&lt;pb xml:id="F1818_v2_089" n="085"/&gt;vice of his </rdg>
+			<rdg wit="f1831">in the service of his </rdg>
+			<rdg wit="fMS">&lt;mdel&gt;t&lt;/mdel&gt;&lt;sga-add place="intralinear"
+				sID="c57-0031__main__d4e4943"/&gt;i&lt;sga-add eID="c57-0031__main__d4e4943"/&gt;n
+				the service of his</rdg>
 		</rdgGrp>
 	</app>
 
@@ -392,8 +384,8 @@
 			<rdg wit="fThomas">ranked</rdg>
 			<rdg wit="f1831">ranked</rdg>
 		</rdgGrp>
-		<rdgGrp n="['', '&lt;delstart/&gt;been&lt;delend/&gt;', 'ranked']">
-			<rdg wit="fMS">&lt;mod sID="c57-0031__main__d4e4949"/&gt; &lt;del rend="strikethrough"
+		<rdgGrp n="['&lt;delstart/&gt;been&lt;delend/&gt;', 'ranked']">
+			<rdg wit="fMS">&lt;del rend="strikethrough"
 				xml:id="c57-0031__main__d4e4951"&gt;been&lt;/del&gt; &lt;sga-add place="superlinear"
 				sID="c57-0031__main__d4e4954"/&gt;ranked</rdg>
 		</rdgGrp>
@@ -421,9 +413,8 @@
 			<rdg wit="f1823">of the highest distinction. A few months </rdg>
 			<rdg wit="fThomas">of the highest distinction. A few months </rdg>
 			<rdg wit="f1831">of the highest distinction. A few months </rdg>
-			<rdg wit="fMS">&lt;sga-add eID="c57-0031__main__d4e4963"/&gt;&lt;mod
-				eID="c57-0031__main__d4e4949"/&gt;of the &lt;lb n="c57-0031__main__16"/&gt;highest
-				distinction. A few months</rdg>
+			<rdg wit="fMS">&lt;sga-add eID="c57-0031__main__d4e4963"/&gt;of the &lt;lb
+				n="c57-0031__main__16"/&gt;highest distinction. A few months</rdg>
 		</rdgGrp>
 	</app>
 
@@ -525,20 +516,17 @@
 			<rdg wit="fThomas">which</rdg>
 			<rdg wit="f1831">which</rdg>
 		</rdgGrp>
-		<rdgGrp n="['that', '', '&lt;delstart/&gt;that&lt;delend/&gt;', 'which']">
-			<rdg wit="fMS">that &lt;mod sID="c57-0031__main__d4e4992"/&gt; &lt;del
-				rend="strikethrough" xml:id="c57-0031__main__d4e4994"&gt;that&lt;/del&gt;
-				&lt;sga-add hand="#pbs" place="superlinear"
-				sID="c57-0031__main__d4e4997"/&gt;which</rdg>
+		<rdgGrp n="['that', '&lt;delstart/&gt;that&lt;delend/&gt;', 'which']">
+			<rdg wit="fMS">that &lt;del rend="strikethrough"
+				xml:id="c57-0031__main__d4e4994"&gt;that&lt;/del&gt; &lt;sga-add hand="#pbs"
+				place="superlinear" sID="c57-0031__main__d4e4997"/&gt;which</rdg>
 		</rdgGrp>
 	</app>
 
 	<app>
 		<rdgGrp n="['', 'virtue', '', '', 'and']">
-			<rdg wit="fMS">&lt;sga-add eID="c57-0031__main__d4e4997"/&gt;&lt;mod
-				eID="c57-0031__main__d4e4992"/&gt; virtue &lt;mod
-				sID="c57-0031__main__d4e5001"/&gt;&lt;sga-add place="sublinear"
-				sID="c57-0031__main__d4e5003"/&gt; &lt;metamark
+			<rdg wit="fMS">&lt;sga-add eID="c57-0031__main__d4e4997"/&gt; virtue &lt;sga-add
+				place="sublinear" sID="c57-0031__main__d4e5003"/&gt; &lt;metamark
 				function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
 				eID="c57-0031__main__d4e5003"/&gt;&lt;sga-add hand="#pbs" next="#c57-0031.10"
 				place="superlinear" sID="c57-0031__main__d4e5009"/&gt;&amp;</rdg>
@@ -576,9 +564,9 @@
 			<rdg wit="f1823">taste, accompanied</rdg>
 			<rdg wit="fThomas">taste, accompanied</rdg>
 			<rdg wit="f1831">taste, accompanied</rdg>
-			<rdg wit="fMS">taste, &lt;sga-add eID="c57-0031__main__d4e5009"/&gt;&lt;mod
-				eID="c57-0031__main__d4e5001"/&gt;&lt;w ana="start"/&gt;ac&lt;lb
-				n="c57-0031__main__20"/&gt;companied&lt;w ana="end"/&gt;</rdg>
+			<rdg wit="fMS">taste, &lt;sga-add eID="c57-0031__main__d4e5009"/&gt;&lt;w
+				ana="start"/&gt;ac&lt;lb n="c57-0031__main__20"/&gt;companied&lt;w
+				ana="end"/&gt;</rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -653,8 +641,8 @@
 			<rdg wit="fThomas">had been</rdg>
 			<rdg wit="f1831">had been</rdg>
 		</rdgGrp>
-		<rdgGrp n="['', '&lt;delstart/&gt;was&lt;delend/&gt;', 'had', 'been']">
-			<rdg wit="fMS">&lt;mod sID="c57-0031__main__d4e5027"/&gt; &lt;del rend="strikethrough"
+		<rdgGrp n="['&lt;delstart/&gt;was&lt;delend/&gt;', 'had', 'been']">
+			<rdg wit="fMS">&lt;del rend="strikethrough"
 				xml:id="c57-0031__main__d4e5029"&gt;was&lt;/del&gt; &lt;sga-add place="superlinear"
 				sID="c57-0031__main__d4e5032"/&gt;had been</rdg>
 		</rdgGrp>
@@ -666,18 +654,16 @@
 			<rdg wit="f1823">the cause of their </rdg>
 			<rdg wit="fThomas">the cause of their </rdg>
 			<rdg wit="f1831">the cause of their </rdg>
-			<rdg wit="fMS">&lt;sga-add eID="c57-0031__main__d4e5032"/&gt;&lt;mod
-				eID="c57-0031__main__d4e5027"/&gt;the cause of their</rdg>
+			<rdg wit="fMS">&lt;sga-add eID="c57-0031__main__d4e5032"/&gt;the cause of their</rdg>
 		</rdgGrp>
 	</app>
 
 	<app>
 		<rdgGrp n="['', '&lt;delstart/&gt;fall&lt;delend/&gt;', 'ruin;', '']">
-			<rdg wit="fMS">&lt;lb n="c57-0031__main__23"/&gt;&lt;mod
-				sID="c57-0031__main__d4e5038"/&gt; &lt;del rend="strikethrough"
+			<rdg wit="fMS">&lt;lb n="c57-0031__main__23"/&gt; &lt;del rend="strikethrough"
 				xml:id="c57-0031__main__d4e5040"&gt;fall&lt;/del&gt; &lt;sga-add hand="#pbs"
 				place="superlinear" sID="c57-0031__main__d4e5043"/&gt;ruin; &lt;sga-add
-				eID="c57-0031__main__d4e5043"/&gt;&lt;mod eID="c57-0031__main__d4e5038"/&gt;</rdg>
+				eID="c57-0031__main__d4e5043"/&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp n="['ruin.']">
 			<rdg wit="f1818">ruin.</rdg>
@@ -697,16 +683,13 @@
 	</app>
 	<app>
 		<rdgGrp n="['turkish']">
-			<rdg wit="f1818">Turkish</rdg>
-			<rdg wit="f1823">Turkish</rdg>
-			<rdg wit="fThomas">Turkish</rdg>
-			<rdg wit="f1831">Turkish</rdg>
-		</rdgGrp>
-		<rdgGrp n="['', '&lt;mdel&gt;t&lt;/mdel&gt;', 'turkish']">
-			<rdg wit="fMS">&lt;mod sID="c57-0031__main__d4e5047"/&gt; &lt;mdel&gt;t&lt;/mdel&gt;
-				&lt;sga-add place="intralinear" sID="c57-0031__main__d4e5051"/&gt;T&lt;sga-add
-				eID="c57-0031__main__d4e5051"/&gt;&lt;mod
-				eID="c57-0031__main__d4e5047"/&gt;urkish</rdg>
+			<rdg wit="f1818">Turkish </rdg>
+			<rdg wit="f1823">Turkish </rdg>
+			<rdg wit="fThomas">Turkish </rdg>
+			<rdg wit="f1831">Turkish </rdg>
+			<rdg wit="fMS">&lt;mdel&gt;t&lt;/mdel&gt;&lt;sga-add place="intralinear"
+				sID="c57-0031__main__d4e5051"/&gt;T&lt;sga-add
+				eID="c57-0031__main__d4e5051"/&gt;urkish</rdg>
 		</rdgGrp>
 	</app>
 
@@ -752,11 +735,10 @@
 			<rdg wit="f1831">years, when,</rdg>
 		</rdgGrp>
 		<rdgGrp
-			n="['years.', 'when', 'his', 'person', 'became', '', '&lt;delstart/&gt;for some&lt;delend/&gt;', '', '']">
-			<rdg wit="fMS">years. When his person &lt;lb n="c57-0031__main__25"/&gt;became &lt;mod
-				sID="c57-0031__main__d4e5063"/&gt; &lt;del rend="strikethrough"
-				xml:id="c57-0031__main__d4e5065"&gt;for some&lt;/del&gt; &lt;sga-add
-				place="sublinear" sID="c57-0031__main__d4e5068"/&gt; &lt;metamark
+			n="['years.', 'when', 'his', 'person', 'became', '&lt;delstart/&gt;for some&lt;delend/&gt;', '', '']">
+			<rdg wit="fMS">years. When his person &lt;lb n="c57-0031__main__25"/&gt;became &lt;del
+				rend="strikethrough" xml:id="c57-0031__main__d4e5065"&gt;for some&lt;/del&gt;
+				&lt;sga-add place="sublinear" sID="c57-0031__main__d4e5068"/&gt; &lt;metamark
 				function="insert"&gt;^&lt;/metamark&gt;</rdg>
 		</rdgGrp>
 	</app>
@@ -773,8 +755,7 @@
 	</app>
 	<app>
 		<rdgGrp n="['learn', '']">
-			<rdg wit="fMS">learn &lt;sga-add eID="c57-0031__main__d4e5074"/&gt;&lt;mod
-				eID="c57-0031__main__d4e5063"/&gt;</rdg>
+			<rdg wit="fMS">learn &lt;sga-add eID="c57-0031__main__d4e5074"/&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp n="['learn,', 'he', 'became']">
 			<rdg wit="f1818">learn, he became</rdg>
@@ -908,10 +889,9 @@
 			n="['wealth', '', '&lt;delstart/&gt;had been the causes of his condemnation rather&lt;delend/&gt;', '', '&lt;delstart/&gt;than&lt;delend/&gt;']">
 			<rdg wit="fMS">wealth &lt;lb n="c57-0031__main__32"/&gt; &lt;del rend="strikethrough"
 				xml:id="c57-0031__main__d4e5105"&gt;had been the causes of his condemnation
-				rather&lt;/del&gt; &lt;lb n="c57-0032__main__1"/&gt;&lt;mod
-				sID="c57-0032__main__d4e5118"/&gt;&lt;anchor xml:id="c57-0032.01"/&gt;&lt;lb
-				n="c57-0032__left_margin__1"/&gt; &lt;del rend="smear"
-				xml:id="c57-0032__left_margin__d4e5126"&gt;than&lt;/del&gt;</rdg>
+				rather&lt;/del&gt; &lt;lb n="c57-0032__main__1"/&gt;&lt;anchor
+				xml:id="c57-0032.01"/&gt;&lt;lb n="c57-0032__left_margin__1"/&gt; &lt;del
+				rend="smear" xml:id="c57-0032__left_margin__d4e5126"&gt;than&lt;/del&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp n="['wealth,']">
 			<rdg wit="f1818">wealth,</rdg>
@@ -938,8 +918,7 @@
 			<rdg wit="f1823">the &lt;pb xml:id="F1823_v2_291" n="18"/&gt;crime </rdg>
 			<rdg wit="fThomas">the &lt;pb xml:id="F1818_v2_090" n="086"/&gt;crime </rdg>
 			<rdg wit="f1831">the crime </rdg>
-			<rdg wit="fMS">&lt;sga-add eID="c57-0032__main__d4e5133"/&gt;&lt;mod
-				eID="c57-0032__main__d4e5118"/&gt;the crime</rdg>
+			<rdg wit="fMS">&lt;sga-add eID="c57-0032__main__d4e5133"/&gt;the crime</rdg>
 		</rdgGrp>
 	</app>
 
@@ -1038,17 +1017,13 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['', '', 'w', '&lt;mdel&gt;as&lt;/mdel&gt;', 'ere', '', 'uncontrolable']">
-			<rdg wit="fMS">&lt;mod sID="c57-0032__main__d4e5163"/&gt;&lt;sga-add place="sublinear"
-				sID="c57-0032__main__d4e5165"/&gt; &lt;metamark
-				function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
+		<rdgGrp n="['', '', 'w', '', 'ere', '', 'uncontrolable']">
+			<rdg wit="fMS">&lt;sga-add place="sublinear" sID="c57-0032__main__d4e5165"/&gt;
+				&lt;metamark function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
 				eID="c57-0032__main__d4e5165"/&gt;&lt;sga-add place="superlinear"
-				sID="c57-0032__main__d4e5171"/&gt;w&lt;mod sID="c57-0032__main__d4e5173"/&gt;
-				&lt;mdel&gt;as&lt;/mdel&gt; &lt;sga-add hand="#pbs" place="intralinear"
-				sID="c57-0032__main__d4e5177"/&gt;ere &lt;sga-add
-				eID="c57-0032__main__d4e5177"/&gt;&lt;mod
-				eID="c57-0032__main__d4e5173"/&gt;&lt;sga-add
-				eID="c57-0032__main__d4e5171"/&gt;&lt;mod eID="c57-0032__main__d4e5163"/&gt;
+				sID="c57-0032__main__d4e5171"/&gt;w &lt;mdel&gt;as&lt;/mdel&gt; &lt;sga-add
+				hand="#pbs" place="intralinear" sID="c57-0032__main__d4e5177"/&gt;ere &lt;sga-add
+				eID="c57-0032__main__d4e5177"/&gt;&lt;sga-add eID="c57-0032__main__d4e5171"/&gt;
 				uncontrolable</rdg>
 		</rdgGrp>
 		<rdgGrp n="['were', 'uncontrollable,']">
@@ -1075,9 +1050,8 @@
 			<rdg wit="f1831">decision of the court.</rdg>
 		</rdgGrp>
 		<rdgGrp
-			n="['', '&lt;delstart/&gt;event.&lt;delend/&gt;', '', '&lt;mdel&gt;of&lt;/mdel&gt;', 'decision', 'of', 'the', 'court.']">
-			<rdg wit="fMS">&lt;lb n="c57-0032__main__4"/&gt;&lt;mod
-				sID="c57-0032__main__d4e5185"/&gt; &lt;del rend="strikethrough"
+			n="['', '&lt;delstart/&gt;event.&lt;delend/&gt;', '', '', 'decision', 'of', 'the', 'court.']">
+			<rdg wit="fMS">&lt;lb n="c57-0032__main__4"/&gt; &lt;del rend="strikethrough"
 				xml:id="c57-0032__main__d4e5187"&gt;event.&lt;/del&gt; &lt;sga-add hand="#pbs"
 				place="superlinear" sID="c57-0032__main__d4e5190"/&gt; &lt;mdel&gt;of&lt;/mdel&gt;
 				decision of the court.</rdg>
@@ -1090,8 +1064,7 @@
 			<rdg wit="f1823">He </rdg>
 			<rdg wit="fThomas">He </rdg>
 			<rdg wit="f1831">He </rdg>
-			<rdg wit="fMS">&lt;sga-add eID="c57-0032__main__d4e5190"/&gt;&lt;mod
-				eID="c57-0032__main__d4e5185"/&gt;He</rdg>
+			<rdg wit="fMS">&lt;sga-add eID="c57-0032__main__d4e5190"/&gt;He</rdg>
 		</rdgGrp>
 	</app>
 
@@ -1166,11 +1139,10 @@
 		<rdgGrp n="['prison', '&lt;delstart/&gt;goal&lt;delend/&gt;', 'prison', '']">
 			<rdg wit="fMS">&lt;delSpan rend="strikethrough" spanTo="#c57-0032.04"/&gt;&lt;w
 				ana="start"/&gt;pri&lt;lb n="c57-0032__main__8"/&gt;son&lt;w
-				ana="end"/&gt;&lt;anchor xml:id="c57-0032.04"/&gt;&lt;mod
-				sID="c57-0032__main__d4e5214"/&gt; &lt;del rend="strikethrough"
+				ana="end"/&gt;&lt;anchor xml:id="c57-0032.04"/&gt; &lt;del rend="strikethrough"
 				xml:id="c57-0032__main__d4e5216"&gt;goal&lt;/del&gt; &lt;sga-add hand="#pbs"
 				place="superlinear" sID="c57-0032__main__d4e5219"/&gt;prison &lt;sga-add
-				eID="c57-0032__main__d4e5219"/&gt;&lt;mod eID="c57-0032__main__d4e5214"/&gt;</rdg>
+				eID="c57-0032__main__d4e5219"/&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp n="['prison,']">
 			<rdg wit="f1818">prison,</rdg>
@@ -1190,12 +1162,10 @@
 	</app>
 	<app>
 		<rdgGrp n="['st', '', '', 'r', '', 'ongly']">
-			<rdg wit="fMS">st &lt;mod sID="c57-0032__main__d4e5223"/&gt;&lt;sga-add
-				place="sublinear" sID="c57-0032__main__d4e5225"/&gt; &lt;metamark
-				function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
+			<rdg wit="fMS">st &lt;sga-add place="sublinear" sID="c57-0032__main__d4e5225"/&gt;
+				&lt;metamark function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
 				eID="c57-0032__main__d4e5225"/&gt;&lt;sga-add place="superlinear"
-				sID="c57-0032__main__d4e5231"/&gt;r &lt;sga-add
-				eID="c57-0032__main__d4e5231"/&gt;&lt;mod eID="c57-0032__main__d4e5223"/&gt;
+				sID="c57-0032__main__d4e5231"/&gt;r &lt;sga-add eID="c57-0032__main__d4e5231"/&gt;
 				ongly</rdg>
 		</rdgGrp>
 		<rdgGrp n="['strongly']">
@@ -1222,12 +1192,11 @@
 			<rdg wit="fThomas">building, which</rdg>
 			<rdg wit="f1831">building, which</rdg>
 		</rdgGrp>
-		<rdgGrp n="['', '&lt;delstart/&gt;prison&lt;delend/&gt;', 'building,', 'which']">
-			<rdg wit="fMS">&lt;mod sID="c57-0032__main__d4e5237"/&gt; &lt;del rend="strikethrough"
+		<rdgGrp n="['&lt;delstart/&gt;prison&lt;delend/&gt;', 'building,', 'which']">
+			<rdg wit="fMS">&lt;del rend="strikethrough"
 				xml:id="c57-0032__main__d4e5239"&gt;prison&lt;/del&gt; &lt;sga-add hand="#pbs"
 				place="superlinear" sID="c57-0032__main__d4e5242"/&gt;building, &lt;sga-add
-				eID="c57-0032__main__d4e5242"/&gt;&lt;mod eID="c57-0032__main__d4e5237"/&gt;&lt;lb
-				n="c57-0032__main__10"/&gt;which</rdg>
+				eID="c57-0032__main__d4e5242"/&gt;&lt;lb n="c57-0032__main__10"/&gt;which</rdg>
 		</rdgGrp>
 	</app>
 
@@ -1374,15 +1343,13 @@
 			<rdg wit="fThomas">kindle the zeal of his</rdg>
 			<rdg wit="f1831">kindle the zeal of his</rdg>
 		</rdgGrp>
-		<rdgGrp
-			n="['', '&lt;delstart/&gt;warm&lt;delend/&gt;', 'kindle', 'the', 'zeal', 'of', 'his']">
-			<rdg wit="fMS">&lt;mod sID="c57-0032__main__d4e5281"/&gt; &lt;del rend="strikethrough"
+		<rdgGrp n="['&lt;delstart/&gt;warm&lt;delend/&gt;', 'kindle', 'the', 'zeal', 'of', 'his']">
+			<rdg wit="fMS">&lt;del rend="strikethrough"
 				xml:id="c57-0032__main__d4e5283"&gt;warm&lt;/del&gt; &lt;anchor
 				xml:id="c57-0032.05"/&gt;&lt;lb n="c57-0032__left_margin__1"/&gt;&lt;sga-add
 				hand="#pbs" sID="c57-0032__left_margin__d4e5292"/&gt;kindle &lt;sga-add
-				eID="c57-0032__left_margin__d4e5292"/&gt;&lt;mod
-				eID="c57-0032__main__d4e5281"/&gt;&lt;lb n="c57-0032__main__18"/&gt;the zeal of
-				his</rdg>
+				eID="c57-0032__left_margin__d4e5292"/&gt;&lt;lb n="c57-0032__main__18"/&gt;the zeal
+				of his</rdg>
 		</rdgGrp>
 	</app>
 
@@ -1556,15 +1523,13 @@
 				sID="novel1_letter4_chapter14_div4_div14_p5"/&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp
-			n="['', '', '', '&lt;delstart/&gt;', 'altho it had not', 'en ', '&lt;delend/&gt;', '', 'would', 'fully', 'reward', 'his', 'toil', 'and', 'hazard.', '&lt;p-end/&gt;', '&lt;p-start/&gt;']">
-			<rdg wit="fMS">&lt;mod sID="c57-0032__main__d4e5323"/&gt;&lt;sga-add place="sublinear"
-				sID="c57-0032__main__d4e5325"/&gt; &lt;metamark
-				function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
+			n="['', '', '', '&lt;delstart/&gt;', 'altho it had not', 'en ', '&lt;delend/&gt;', 'would', 'fully', 'reward', 'his', 'toil', 'and', 'hazard.', '&lt;p-end/&gt;', '&lt;p-start/&gt;']">
+			<rdg wit="fMS">&lt;sga-add place="sublinear" sID="c57-0032__main__d4e5325"/&gt;
+				&lt;metamark function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
 				eID="c57-0032__main__d4e5325"/&gt; &lt;del rend="strikethrough"
 				xml:id="c57-0032__main__d4e5331"&gt; &lt;sga-add hand="#pbs" place="superlinear"
 				sID="c57-0032__main__d4e5333"/&gt;altho it had not en &lt;sga-add
-				eID="c57-0032__main__d4e5333"/&gt; &lt;/del&gt; &lt;mod
-				eID="c57-0032__main__d4e5323"/&gt; would fully reward his &lt;lb
+				eID="c57-0032__main__d4e5333"/&gt; &lt;/del&gt; would fully reward his &lt;lb
 				n="c57-0032__main__27"/&gt;toil &amp; hazard. &lt;milestone unit="tei:p-END"/&gt;
 				&lt;milestone unit="tei:p-START"/&gt;</rdg>
 		</rdgGrp>
@@ -1643,13 +1608,13 @@
 	</app>
 	<app>
 		<rdgGrp
-			n="['', '&lt;delstart/&gt;re ', '', '&lt;mdel&gt;', '&lt;/mdel&gt;', 's ', 'olved&lt;delend/&gt;', 'endeavored']">
-			<rdg wit="fMS">&lt;mod sID="c57-0033__main__d4e5371"/&gt; &lt;del rend="strikethrough"
-				xml:id="c57-0033__main__d4e5373"&gt;re &lt;mod sID="c57-0033__main__d4e5375"/&gt;
-				&lt;mdel&gt; &lt;/mdel&gt; &lt;sga-add place="intralinear"
-				sID="c57-0033__main__d4e5382"/&gt;s &lt;sga-add eID="c57-0033__main__d4e5382"/&gt;
-				&lt;mod eID="c57-0033__main__d4e5375"/&gt; olved&lt;/del&gt; &lt;anchor
-				xml:id="c57-0033.02"/&gt;&lt;lb n="c57-0033__left_margin__1"/&gt;&lt;sga-add
+			n="['&lt;delstart/&gt;re ', '&lt;mod sid=&#34;c57-0033__main__d4e5375&#34;/&gt;', '&lt;mdel&gt;', '&lt;/mdel&gt;', 's ', '&lt;mod eid=&#34;c57-0033__main__d4e5375&#34;/&gt; olved&lt;delend/&gt;', 'endeavored']">
+			<rdg wit="fMS">&lt;del rend="strikethrough" xml:id="c57-0033__main__d4e5373"&gt;re
+				&lt;mod sID="c57-0033__main__d4e5375"/&gt; &lt;mdel&gt; &lt;/mdel&gt; &lt;sga-add
+				place="intralinear" sID="c57-0033__main__d4e5382"/&gt;s &lt;sga-add
+				eID="c57-0033__main__d4e5382"/&gt; &lt;mod eID="c57-0033__main__d4e5375"/&gt;
+				olved&lt;/del&gt; &lt;anchor xml:id="c57-0033.02"/&gt;&lt;lb
+				n="c57-0033__left_margin__1"/&gt;&lt;sga-add
 				sID="c57-0033__left_margin__d4e5393"/&gt;endeavored</rdg>
 		</rdgGrp>
 		<rdgGrp n="['endeavoured']">
@@ -1665,8 +1630,8 @@
 			<rdg wit="f1823">to secure</rdg>
 			<rdg wit="fThomas">to secure</rdg>
 			<rdg wit="f1831">to secure</rdg>
-			<rdg wit="fMS">&lt;sga-add eID="c57-0033__left_margin__d4e5393"/&gt;&lt;mod
-				eID="c57-0033__main__d4e5371"/&gt;&lt;lb n="c57-0033__main__3"/&gt;to secure</rdg>
+			<rdg wit="fMS">&lt;sga-add eID="c57-0033__left_margin__d4e5393"/&gt;&lt;lb
+				n="c57-0033__main__3"/&gt;to secure</rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -1691,14 +1656,13 @@
 			<rdg wit="fThomas">more entirely</rdg>
 			<rdg wit="f1831">more entirely</rdg>
 		</rdgGrp>
-		<rdgGrp n="['', '&lt;delstart/&gt;at any pr&lt;delend/&gt;', '', '', 'more', 'entirely']">
-			<rdg wit="fMS">&lt;mod sID="c57-0033__main__d4e5405"/&gt; &lt;del rend="strikethrough"
-				xml:id="c57-0033__main__d4e5407"&gt;at any pr&lt;/del&gt; &lt;sga-add
-				place="sublinear" sID="c57-0033__main__d4e5410"/&gt; &lt;metamark
-				function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
+		<rdgGrp n="['&lt;delstart/&gt;at any pr&lt;delend/&gt;', '', '', 'more', 'entirely']">
+			<rdg wit="fMS">&lt;del rend="strikethrough" xml:id="c57-0033__main__d4e5407"&gt;at any
+				pr&lt;/del&gt; &lt;sga-add place="sublinear" sID="c57-0033__main__d4e5410"/&gt;
+				&lt;metamark function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
 				eID="c57-0033__main__d4e5410"/&gt;&lt;sga-add place="superlinear"
 				sID="c57-0033__main__d4e5416"/&gt;more entirely&lt;sga-add
-				eID="c57-0033__main__d4e5416"/&gt;&lt;mod eID="c57-0033__main__d4e5405"/&gt;</rdg>
+				eID="c57-0033__main__d4e5416"/&gt;</rdg>
 		</rdgGrp>
 	</app>
 
@@ -1743,13 +1707,12 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['', '&lt;delstart/&gt;', 'offer ', '&lt;delend/&gt;', 'offer', '']">
-			<rdg wit="fMS">&lt;mod sID="c57-0033__main__d4e5425"/&gt; &lt;del rend="strikethrough"
-				xml:id="c57-0033__main__d4e5427"&gt; &lt;sga-add hand="#pbs" place="superlinear"
-				sID="c57-0033__main__d4e5429"/&gt;offer &lt;sga-add
-				eID="c57-0033__main__d4e5429"/&gt; &lt;/del&gt; &lt;sga-add hand="#pbs"
+		<rdgGrp n="['&lt;delstart/&gt;', 'offer ', '&lt;delend/&gt;', 'offer', '']">
+			<rdg wit="fMS">&lt;del rend="strikethrough" xml:id="c57-0033__main__d4e5427"&gt;
+				&lt;sga-add hand="#pbs" place="superlinear" sID="c57-0033__main__d4e5429"/&gt;offer
+				&lt;sga-add eID="c57-0033__main__d4e5429"/&gt; &lt;/del&gt; &lt;sga-add hand="#pbs"
 				place="superlinear" sID="c57-0033__main__d4e5439"/&gt;offer &lt;sga-add
-				eID="c57-0033__main__d4e5439"/&gt;&lt;mod eID="c57-0033__main__d4e5425"/&gt;</rdg>
+				eID="c57-0033__main__d4e5439"/&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp n="['this', 'offer;']">
 			<rdg wit="f1818">this offer;</rdg>
@@ -2186,9 +2149,8 @@
 			<rdg wit="fThomas">across Mont Cenis to Leghorn, where</rdg>
 			<rdg wit="f1831">across Mont Cenis to Leghorn, where</rdg>
 		</rdgGrp>
-		<rdgGrp n="['rank', '', '&lt;delstart/&gt;her father&lt;delend/&gt;']">
-			<rdg wit="fMS">rank &lt;mod sID="c57-0033__main__d4e5463"/&gt; &lt;del
-				rend="strikethrough" xml:id="c57-0033__main__d4e5465"&gt;her
+		<rdgGrp n="['rank', '&lt;delstart/&gt;her father&lt;delend/&gt;']">
+			<rdg wit="fMS">rank &lt;del rend="strikethrough" xml:id="c57-0033__main__d4e5465"&gt;her
 				father&lt;/del&gt;</rdg>
 		</rdgGrp>
 	</app>
@@ -2204,13 +2166,12 @@
 	</app>
 	<app>
 		<rdgGrp n="['', 'commander', '', '&lt;delstart/&gt;her&lt;delend/&gt;']">
-			<rdg wit="fMS">&lt;sga-add eID="c57-0033__main__d4e5468"/&gt;&lt;mod
-				eID="c57-0033__main__d4e5463"/&gt; commander &lt;lb
-				n="c57-0033__main__13"/&gt;&lt;mod sID="c57-0033__main__d4e5475"/&gt; &lt;del
-				rend="strikethrough" xml:id="c57-0033__main__d4e5477"&gt;her&lt;/del&gt;</rdg>
+			<rdg wit="fMS">&lt;sga-add eID="c57-0033__main__d4e5468"/&gt; commander &lt;lb
+				n="c57-0033__main__13"/&gt; &lt;del rend="strikethrough"
+				xml:id="c57-0033__main__d4e5477"&gt;her&lt;/del&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp
-			n="['had', 'decided', 'to', 'wait', 'a', 'favourable', 'opportunity', 'of', 'passing', 'into', 'some', 'part', 'of', 'the', 'turkish', 'dominions.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&#34;safie', 'resolved', 'to', 'remain', 'with', 'her', 'father', 'until', 'the', 'moment', 'of', 'his', 'departure,', 'before', 'which', 'time', 'the', 'turk', 'renewed', 'his', 'promise', 'that', 'she', 'should', 'be', 'united', 'to', 'his', 'deliverer;', 'and', 'felix', 'remained', 'with', 'them', 'in', 'expectation', 'of', 'that', 'event;', 'and', 'in', 'the', 'mean', 'time', 'he', 'enjoyed', 'the', 'society', 'of', 'the', 'arabian,', 'who', 'exhibited', 'towards', 'him', 'the', 'simplest', 'and', 'tenderest', 'affection.', 'they', 'conversed', 'with', 'one', 'another', 'through', 'the', 'means', 'of', 'an', 'interpreter,', 'and', 'sometimes', 'with', 'the', 'interpretation', 'of', 'looks;', 'and', 'safie', 'sang', 'to', 'him', 'the', 'divine', 'airs', 'of', 'her', 'native', 'country.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&#34;the', 'turk', 'allowed', 'this', 'intimacy', 'to', 'take', 'place,', 'and', 'encouraged', 'the', 'hopes', 'of', 'the', 'youthful', 'lovers,', 'while', 'in', 'his', 'heart', 'he', 'had', 'formed', 'far', 'other', 'plans.', 'he', 'loathed', 'the', 'idea', 'that']">
+			n="['had', 'decided', 'to', 'wait', 'a', 'favourable', 'opportunity', 'of', 'passing', 'into', 'some', 'part', 'of', 'the', 'turkish', 'dominions.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&#34;safie', 'resolved', 'to', 'remain', 'with', 'her', 'father', 'until', 'the', 'moment', 'of', 'his', 'departure,', 'before', 'which', 'time', 'the', 'turk', 'renewed', 'his', 'promise', 'that', 'she', 'should', 'be', 'united', 'to', 'his', 'deliverer;', 'and', 'felix', 'remained', 'with', 'them', 'in', 'expectation', 'of', 'that', 'event;', 'and', 'in', 'the', 'mean', 'time', 'he', 'enjoyed', 'the', 'society', 'of', 'the', 'arabian,', 'who', 'exhibited', 'towards', 'him', 'the', 'simplest', 'and', 'tenderest', 'affection.', 'they', 'conversed', 'with', 'one', 'another', 'through', 'the', 'means', 'of', 'an', 'interpreter,', 'and', 'sometimes', 'with', 'the', 'interpretation', 'of', 'looks;', 'and', 'safie', 'sang', 'to', 'him', 'the', 'divine', 'airs', 'of', 'her', 'native', 'country.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&#34;the', 'turk', 'allowed', 'this', 'intimacy', 'to', 'take', 'place,', 'and', 'encouraged', 'the', 'hopes', 'of', 'the', 'youthful', 'lovers,', 'while', 'in', 'his', 'heart', 'he', 'had', 'formed', 'far', 'other', 'plans.', 'he', 'loathed', 'the', 'idea', 'that', 'his', 'daughter', 'should', 'be', 'united', 'to', 'a', 'christian;', 'but', 'he', 'feared', 'the', 'resentment', 'of']">
 			<rdg wit="f1818">had decided to wait a favourable opportunity of passing into some part
 				of the Turkish dominions. &lt;p eID="novel1_letter4_chapter13_div4_div14_p10"/&gt;
 				&lt;p sID="novel1_letter4_chapter13_div4_div14_p11"/&gt; “Safie resolved to remain
@@ -2224,7 +2185,8 @@
 				eID="novel1_letter4_chapter13_div4_div14_p11"/&gt; &lt;p
 				sID="novel1_letter4_chapter13_div4_div14_p12"/&gt; “The Turk allowed this intimacy
 				to take place, and encouraged the hopes of the youthful lovers, while in his heart
-				he had formed far other plans. He loathed the idea that</rdg>
+				he had formed far other plans. He loathed the idea that his daughter should be
+				united to a Christian; but he feared the resentment of</rdg>
 			<rdg wit="f1823">had decided to wait a favourable opportunity of passing into some part
 				of the Turkish dominions. &lt;p eID="novel1_letter4_chapter13_div4_div14_p10"/&gt;
 				&lt;p sID="novel1_letter4_chapter13_div4_div14_p11"/&gt; “Safie resolved to remain
@@ -2238,7 +2200,8 @@
 				eID="novel1_letter4_chapter13_div4_div14_p11"/&gt; &lt;p
 				sID="novel1_letter4_chapter13_div4_div14_p12"/&gt; “The Turk allowed this intimacy
 				to take place, and encouraged the hopes of the youthful lovers, while in his heart
-				he had formed far other plans. He loathed the idea that</rdg>
+				he had formed far other plans. He loathed the idea that his daughter should be
+				united to a Christian; but he feared the resentment of</rdg>
 			<rdg wit="fThomas">had decided to wait a favourable opportunity of passing into some
 				part of the Turkish dominions. &lt;p
 				eID="novel1_letter4_chapter13_div4_div14_p10"/&gt; &lt;p
@@ -2253,7 +2216,8 @@
 				eID="novel1_letter4_chapter13_div4_div14_p11"/&gt; &lt;p
 				sID="novel1_letter4_chapter13_div4_div14_p12"/&gt; “The Turk allowed this intimacy
 				to take place, and encouraged the hopes of the youthful lovers, while in his heart
-				he had formed far other plans. He loathed the idea that</rdg>
+				he had formed far other plans. He loathed the idea that his daughter should be
+				united to a Christian; but he feared the resentment of</rdg>
 			<rdg wit="f1831">had decided to wait a favourable opportunity of passing into some part
 				of the Turkish dominions. &lt;p eID="novel1_letter4_chapter14_div4_div14_p10"/&gt;
 				&lt;p sID="novel1_letter4_chapter14_div4_div14_p11"/&gt; “Safie resolved to remain
@@ -2266,31 +2230,8 @@
 				country. &lt;p eID="novel1_letter4_chapter14_div4_div14_p11"/&gt; &lt;p
 				sID="novel1_letter4_chapter14_div4_div14_p12"/&gt; “The Turk allowed this intimacy
 				to take place, and encouraged the hopes of the youthful lovers, while in his heart
-				he had formed far other plans. He loathed the idea that</rdg>
-		</rdgGrp>
-	</app>
-	<app>
-		<rdgGrp n="['his', 'daughter']">
-			<rdg wit="f1818">his daughter</rdg>
-			<rdg wit="f1823">his daughter</rdg>
-			<rdg wit="fThomas">his daughter</rdg>
-			<rdg wit="f1831">his daughter</rdg>
-			<rdg wit="fMS">&lt;sga-add place="superlinear" sID="c57-0033__main__d4e5480"/&gt;his
-				daughter</rdg>
-		</rdgGrp>
-	</app>
-	<app>
-		<rdgGrp n="['']">
-			<rdg wit="fMS">&lt;sga-add eID="c57-0033__main__d4e5480"/&gt;&lt;mod
-				eID="c57-0033__main__d4e5475"/&gt;</rdg>
-		</rdgGrp>
-		<rdgGrp
-			n="['should', 'be', 'united', 'to', 'a', 'christian;', 'but', 'he', 'feared', 'the', 'resentment', 'of']">
-			<rdg wit="f1818">should be united to a Christian; but he feared the resentment of</rdg>
-			<rdg wit="f1823">should be united to a Christian; but he feared the resentment of</rdg>
-			<rdg wit="fThomas">should be united to a Christian; but he feared the resentment
-				of</rdg>
-			<rdg wit="f1831">should be united to a Christian; but he feared the resentment of</rdg>
+				he had formed far other plans. He loathed the idea that his daughter should be
+				united to a Christian; but he feared the resentment of</rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -2305,47 +2246,47 @@
 	</app>
 	<app>
 		<rdgGrp
-			n="['if', 'he', 'should', 'appear', 'lukewarm;', 'for', 'he', 'knew', 'that', 'he', 'was', 'still', 'in', 'the', 'power', 'of', 'his', 'deliverer,', 'if', 'he', 'should', 'choose', 'to', 'betray', 'him', 'to', 'the', 'italian', 'state', 'which', 'they', 'inhabited.', 'he', 'revolved', 'a', 'thousand', 'plans', 'by', 'which', 'he', 'should', 'be', 'enabled', 'to', 'prolong', 'the', 'deceit', 'until', 'it', 'might', 'be', 'no', 'longer', 'necessary,', 'and', 'secretly']">
+			n="['if', 'he', 'should', 'appear', 'lukewarm;', 'for', 'he', 'knew', 'that', 'he', 'was', 'still', 'in', 'the', 'power', 'of', 'his', 'deliverer,', 'if', 'he', 'should', 'choose', 'to', 'betray', 'him', 'to', 'the', 'italian', 'state', 'which', 'they', 'inhabited.', 'he', 'revolved', 'a', 'thousand', 'plans', 'by', 'which', 'he', 'should', 'be', 'enabled', 'to', 'prolong', 'the', 'deceit', 'until', 'it', 'might', 'be', 'no', 'longer', 'necessary,', 'and', 'secretly', 'to', 'take']">
 			<rdg wit="f1818">if he should appear lukewarm; for he knew that he was still in the
 				power of his deliverer, if he should choose to betray &lt;pb xml:id="F1818_v2_096"
 				n="092"/&gt;him to the Italian state which they inhabited. He revolved a thousand
 				plans by which he should be enabled to prolong the deceit until it might be no
-				longer necessary, and secretly</rdg>
+				longer necessary, and secretly to take</rdg>
 			<rdg wit="f1823">if he should appear lukewarm; for he knew that he was still in the
 				power of his deliverer, if he should choose to betray &lt;pb xml:id="F1823_v2_297"
 				n="24"/&gt;him to the Italian state which they inhabited. He revolved a thousand
 				plans by which he should be enabled to prolong the deceit until it might be no
-				longer necessary, and secretly</rdg>
+				longer necessary, and secretly to take</rdg>
 			<rdg wit="fThomas">if he should appear lukewarm; for he knew that he was still in the
 				power of his deliverer, if he should choose to betray &lt;pb xml:id="F1818_v2_096"
 				n="092"/&gt;him to the Italian state which they inhabited. He revolved a thousand
 				plans by which he should be enabled to prolong the deceit until it might be no
-				longer necessary, and secretly</rdg>
+				longer necessary, and secretly to take</rdg>
 			<rdg wit="f1831">if he should appear lukewarm; for he knew that he was still in the
 				power of his deliverer, if he should choose to betray him to the Italian state which
 				they inhabited. He revolved a thousand plans by which he should be enabled to
-				prolong the deceit until it might be no longer necessary, and secretly</rdg>
+				prolong the deceit until it might be no longer necessary, and secretly to take</rdg>
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['to']">
-			<rdg wit="f1818">to</rdg>
-			<rdg wit="f1823">to</rdg>
-			<rdg wit="fThomas">to</rdg>
-			<rdg wit="f1831">to</rdg>
-			<rdg wit="fMS">to</rdg>
+		<rdgGrp n="['his', 'daughter']">
+			<rdg wit="f1818">his daughter</rdg>
+			<rdg wit="f1823">his daughter</rdg>
+			<rdg wit="fThomas">his daughter</rdg>
+			<rdg wit="f1831">his daughter</rdg>
+			<rdg wit="fMS">&lt;sga-add place="superlinear" sID="c57-0033__main__d4e5480"/&gt;his
+				daughter</rdg>
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp
-			n="['take', 'his', 'daughter', 'with', 'him', 'when', 'he', 'departed.', 'his', 'plans', 'were']">
-			<rdg wit="f1818">take his daughter with him when he departed. His plans were</rdg>
-			<rdg wit="f1823">take his daughter with him when he departed. His plans were</rdg>
-			<rdg wit="fThomas">take his daughter with him when he departed. His plans were</rdg>
-			<rdg wit="f1831">take his daughter with him when he departed. His plans were</rdg>
+		<rdgGrp n="['']">
+			<rdg wit="fMS">&lt;sga-add eID="c57-0033__main__d4e5480"/&gt;</rdg>
 		</rdgGrp>
-		<rdgGrp n="['think']">
-			<rdg wit="fMS">think</rdg>
+		<rdgGrp n="['with', 'him', 'when', 'he', 'departed.', 'his', 'plans', 'were']">
+			<rdg wit="f1818">with him when he departed. His plans were</rdg>
+			<rdg wit="f1823">with him when he departed. His plans were</rdg>
+			<rdg wit="fThomas">with him when he departed. His plans were</rdg>
+			<rdg wit="f1831">with him when he departed. His plans were</rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -2357,59 +2298,44 @@
 	</app>
 	<app>
 		<rdgGrp
-			n="['facilitated', 'by', 'the', 'news', 'which', 'arrived', 'from', 'paris.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&#34;the', 'government', 'of', 'france', 'were', 'greatly', 'enraged', 'at', 'the', 'escape', 'of', 'their', 'victim,', 'and', 'spared']">
+			n="['facilitated', 'by', 'the', 'news', 'which', 'arrived', 'from', 'paris.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&#34;the', 'government', 'of', 'france', 'were', 'greatly', 'enraged', 'at', 'the', 'escape', 'of', 'their', 'victim,', 'and', 'spared', 'no', 'pains', 'to', 'detect', 'and', 'punish', 'his', 'deliverer.', 'the', 'plot', 'of', 'felix', 'was', 'quickly', 'discovered,', 'and', 'de', 'lacey', 'and', 'agatha', 'were', 'thrown', 'into', 'prison.', 'the', 'news', 'reached', 'felix,', 'and', 'roused', 'him', 'from', 'his', 'dream', 'of', 'pleasure.', 'his', 'blind', 'and', 'aged', 'father,', 'and', 'his', 'gentle', 'sister,', 'lay', 'in', 'a', 'noisome', 'dungeon,', 'while', 'he', 'enjoyed', 'the', 'free', 'air,', 'and', 'the', 'society', 'of', 'her', 'whom', 'he', 'loved.', 'this', 'idea', 'was', 'torture', 'to', 'him.', 'he', 'quickly', 'arranged', 'with', 'the']">
 			<rdg wit="f1818">facilitated by the news which arrived from Paris. &lt;p
 				eID="novel1_letter4_chapter13_div4_div14_p12"/&gt; &lt;p
 				sID="novel1_letter4_chapter13_div4_div14_p13"/&gt; “The government of France were
-				greatly enraged at the escape of their victim, and spared</rdg>
+				greatly enraged at the escape of their victim, and spared no pains to detect and
+				punish his deliverer. The plot of Felix was quickly discovered, and De Lacey and
+				Agatha were thrown into prison. The news reached Felix, and roused him from his
+				dream of pleasure. His blind and aged father, and his gentle sister, lay in a
+				noisome dungeon, while he enjoyed the free air, and the society of her whom he
+				loved. This idea was torture to him. He quickly arranged with the</rdg>
 			<rdg wit="f1823">facilitated by the news which arrived from Paris. &lt;p
 				eID="novel1_letter4_chapter13_div4_div14_p12"/&gt; &lt;p
 				sID="novel1_letter4_chapter13_div4_div14_p13"/&gt; “The government of France were
-				greatly enraged at the escape of their victim, and spared</rdg>
+				greatly enraged at the escape of their victim, and spared no pains to detect and
+				punish his deliverer. The plot of Felix was quickly discovered, and De Lacey and
+				Agatha were thrown into prison. The news reached Felix, and roused him from his
+				dream of pleasure. His blind and aged father, and his gentle sister, lay in a
+				noisome dungeon, while he enjoyed the free air, and the society of her whom he
+				loved. This idea was torture to him. He quickly arranged with the</rdg>
 			<rdg wit="fThomas">facilitated by the news which arrived from Paris. &lt;p
 				eID="novel1_letter4_chapter13_div4_div14_p12"/&gt; &lt;p
 				sID="novel1_letter4_chapter13_div4_div14_p13"/&gt; “The government of France were
-				greatly enraged at the escape of their victim, and spared</rdg>
+				greatly enraged at the escape of their victim, and spared no pains to detect and
+				punish his deliverer. The plot of Felix was quickly discovered, and De Lacey and
+				Agatha were thrown into prison. The news reached Felix, and roused him from his
+				dream of pleasure. His blind and aged father, and his gentle sister, lay in a
+				noisome dungeon, while he enjoyed the free air, and the society of her whom he
+				loved. This idea was torture to him. He quickly arranged with the</rdg>
 			<rdg wit="f1831">facilitated by the news which arrived from Paris. &lt;p
 				eID="novel1_letter4_chapter14_div4_div14_p12"/&gt; &lt;p
 				sID="novel1_letter4_chapter14_div4_div14_p13"/&gt; “The government of France were
-				greatly enraged at the escape of their victim, and spared</rdg>
-		</rdgGrp>
-	</app>
-	<app>
-		<rdgGrp n="['no']">
-			<rdg wit="f1818">no</rdg>
-			<rdg wit="f1823">no</rdg>
-			<rdg wit="fThomas">no</rdg>
-			<rdg wit="f1831">no</rdg>
-			<rdg wit="fMS">no</rdg>
-		</rdgGrp>
-	</app>
-	<app>
-		<rdgGrp
-			n="['pains', 'to', 'detect', 'and', 'punish', 'his', 'deliverer.', 'the', 'plot', 'of', 'felix', 'was', 'quickly', 'discovered,', 'and', 'de', 'lacey', 'and', 'agatha', 'were', 'thrown', 'into', 'prison.', 'the', 'news', 'reached', 'felix,', 'and', 'roused', 'him', 'from', 'his', 'dream', 'of', 'pleasure.', 'his', 'blind', 'and', 'aged', 'father,', 'and', 'his', 'gentle', 'sister,', 'lay', 'in', 'a', 'noisome', 'dungeon,', 'while', 'he', 'enjoyed', 'the', 'free', 'air,', 'and', 'the', 'society', 'of', 'her', 'whom', 'he', 'loved.', 'this', 'idea', 'was', 'torture', 'to', 'him.', 'he', 'quickly', 'arranged', 'with', 'the']">
-			<rdg wit="f1818">pains to detect and punish his deliverer. The plot of Felix was quickly
-				discovered, and De Lacey and Agatha were thrown into prison. The news reached Felix,
-				and roused him from his dream of pleasure. His blind and aged father, and his gentle
-				sister, lay in a noisome dungeon, while he enjoyed the free air, and the society of
-				her whom he loved. This idea was torture to him. He quickly arranged with the</rdg>
-			<rdg wit="f1823">pains to detect and punish his deliverer. The plot of Felix was quickly
-				discovered, and De Lacey and Agatha were thrown into prison. The news reached Felix,
-				and roused him from his dream of pleasure. His blind and aged father, and his gentle
-				sister, lay in a noisome dungeon, while he enjoyed the free air, and the society of
-				her whom he loved. This idea was torture to him. He quickly arranged with the</rdg>
-			<rdg wit="fThomas">pains to detect and punish his deliverer. The plot of Felix was
-				quickly discovered, and De Lacey and Agatha were thrown into prison. The news
-				reached Felix, and roused him from his dream of pleasure. His blind and aged father,
-				and his gentle sister, lay in a noisome dungeon, while he enjoyed the free air, and
-				the society of her whom he loved. This idea was torture to him. He quickly arranged
-				with the</rdg>
-			<rdg wit="f1831">pains to detect and punish his deliverer. The plot of Felix was quickly
-				discovered, and De Lacey and Agatha were thrown into prison. The news reached Felix,
-				and roused him from his dream of pleasure. His blind and aged father, and his gentle
-				sister, lay in a noisome dungeon, while he enjoyed the free air, and the society of
-				her whom he loved. This idea was &lt;pb xml:id="F1831_v_124" n="108"/&gt;torture to
-				him. He quickly arranged with the</rdg>
+				greatly enraged at the escape of their victim, and spared no pains to detect and
+				punish his deliverer. The plot of Felix was quickly discovered, and De Lacey and
+				Agatha were thrown into prison. The news reached Felix, and roused him from his
+				dream of pleasure. His blind and aged father, and his gentle sister, lay in a
+				noisome dungeon, while he enjoyed the free air, and the society of her whom he
+				loved. This idea was &lt;pb xml:id="F1831_v_124" n="108"/&gt;torture to him. He
+				quickly arranged with the</rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -2601,71 +2527,44 @@
 	</app>
 	<app>
 		<rdgGrp
-			n="['gloried', 'in', 'it:', 'but', 'the', 'ingratitude', 'of', 'the', 'turk,', 'and', 'the', 'loss', 'of', 'his', 'beloved', 'safie,', 'were', 'misfortunes']">
+			n="['gloried', 'in', 'it:', 'but', 'the', 'ingratitude', 'of', 'the', 'turk,', 'and', 'the', 'loss', 'of', 'his', 'beloved', 'safie,', 'were', 'misfortunes', 'more', 'bitter', 'and', 'irreparable.', 'the', 'arrival', 'of', 'the', 'arabian', 'now', 'infused', 'new', 'life', 'into', 'his', 'soul.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&#34;when', 'the', 'news', 'reached', 'leghorn,', 'that', 'felix', 'was', 'deprived', 'of', 'his', 'wealth', 'and', 'rank,', 'the', 'merchant', 'commanded', 'his', 'daughter']">
 			<rdg wit="f1818">gloried in it: but the ingratitude of the Turk, and the loss of his
-				beloved Safie, were misfortunes</rdg>
+				beloved Safie, were misfortunes more bitter and irreparable. The arrival of the
+				Arabian now infused new life into his soul. &lt;p
+				eID="novel1_letter4_chapter13_div4_div14_p16"/&gt; &lt;p
+				sID="novel1_letter4_chapter13_div4_div14_p17"/&gt; “When the news reached Leghorn,
+				that Felix was deprived of his wealth and rank, the merchant commanded his
+				daughter</rdg>
 			<rdg wit="f1823">gloried in it: but the ingratitude of the Turk, and the loss of his
-				beloved Safie, were misfortunes</rdg>
+				beloved Safie, were misfortunes more bitter and irreparable. The arrival of the
+				Arabian now infused new life into his soul. &lt;p
+				eID="novel1_letter4_chapter13_div4_div14_p16"/&gt; &lt;p
+				sID="novel1_letter4_chapter13_div4_div14_p17"/&gt; “When the news reached Leghorn,
+				that Felix was deprived of his wealth and rank, the merchant commanded his
+				daughter</rdg>
 			<rdg wit="fThomas">gloried in it: but the ingratitude of the Turk, and the loss of his
-				beloved Safie, were misfortunes</rdg>
-			<rdg wit="f1831">gloried in it: but the ingratitude of the Turk, and the loss of his
-				beloved Safie, were misfortunes</rdg>
-		</rdgGrp>
-	</app>
-	<app>
-		<rdgGrp n="['more']">
-			<rdg wit="f1818">more</rdg>
-			<rdg wit="f1823">more</rdg>
-			<rdg wit="fThomas">more</rdg>
-			<rdg wit="f1831">more</rdg>
-			<rdg wit="fMS">more</rdg>
-		</rdgGrp>
-	</app>
-	<app>
-		<rdgGrp
-			n="['bitter', 'and', 'irreparable.', 'the', 'arrival', 'of', 'the', 'arabian', 'now', 'infused', 'new', 'life', 'into', 'his', 'soul.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&#34;when', 'the', 'news', 'reached', 'leghorn,', 'that', 'felix', 'was', 'deprived']">
-			<rdg wit="f1818">bitter and irreparable. The arrival of the Arabian now infused new life
-				into his soul. &lt;p eID="novel1_letter4_chapter13_div4_div14_p16"/&gt; &lt;p
-				sID="novel1_letter4_chapter13_div4_div14_p17"/&gt; “When the news reached Leghorn,
-				that Felix was deprived</rdg>
-			<rdg wit="f1823">bitter and irreparable. The arrival of the Arabian now infused new life
-				into his soul. &lt;p eID="novel1_letter4_chapter13_div4_div14_p16"/&gt; &lt;p
-				sID="novel1_letter4_chapter13_div4_div14_p17"/&gt; “When the news reached Leghorn,
-				that Felix was deprived</rdg>
-			<rdg wit="fThomas">bitter and irreparable. The arrival of the Arabian now infused new
-				life into his soul. &lt;p eID="novel1_letter4_chapter13_div4_div14_p15"/&gt; &lt;p
+				beloved Safie, were misfortunes more bitter and irreparable. The arrival of the
+				Arabian now infused new life into his soul. &lt;p
+				eID="novel1_letter4_chapter13_div4_div14_p15"/&gt; &lt;p
 				sID="novel1_letter4_chapter13_div4_div14_p16"/&gt; “When the news reached Leghorn,
-				that Felix was deprived</rdg>
-			<rdg wit="f1831">bitter and irreparable. The arrival of the Arabian now infused new life
-				into his soul. &lt;p eID="novel1_letter4_chapter14_div4_div14_p16"/&gt; &lt;p
+				that Felix was deprived of his wealth and rank, the merchant commanded his
+				daughter</rdg>
+			<rdg wit="f1831">gloried in it: but the ingratitude of the Turk, and the loss of his
+				beloved Safie, were misfortunes more bitter and irreparable. The arrival of the
+				Arabian now infused new life into his soul. &lt;p
+				eID="novel1_letter4_chapter14_div4_div14_p16"/&gt; &lt;p
 				sID="novel1_letter4_chapter14_div4_div14_p17"/&gt; “When the news reached Leghorn,
-				that Felix was deprived</rdg>
+				that Felix was deprived of his wealth and rank, the merchant commanded his
+				daughter</rdg>
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['of']">
-			<rdg wit="f1818">of</rdg>
-			<rdg wit="f1823">of</rdg>
-			<rdg wit="fThomas">of</rdg>
-			<rdg wit="f1831">of</rdg>
-			<rdg wit="fMS">of</rdg>
-		</rdgGrp>
-	</app>
-	<app>
-		<rdgGrp n="['', '&lt;delstart/&gt;him&lt;delend/&gt;']">
-			<rdg wit="fMS">&lt;mod sID="c57-0033__main__d4e5484"/&gt; &lt;del rend="strikethrough"
-				xml:id="c57-0033__main__d4e5486"&gt;him&lt;/del&gt;</rdg>
-		</rdgGrp>
-		<rdgGrp
-			n="['his', 'wealth', 'and', 'rank,', 'the', 'merchant', 'commanded', 'his', 'daughter', 'to', 'think', 'no', 'more', 'of']">
-			<rdg wit="f1818">his wealth and rank, the merchant commanded his daughter to think no
-				more of</rdg>
-			<rdg wit="f1823">his wealth and rank, the merchant commanded his daughter to think no
-				more of</rdg>
-			<rdg wit="fThomas">his wealth and rank, the merchant commanded his daughter to think no
-				more of</rdg>
-			<rdg wit="f1831">his wealth and rank, the merchant commanded his daughter to think no
-				more of</rdg>
+		<rdgGrp n="['to', 'think', 'no', 'more', 'of']">
+			<rdg wit="f1818">to think no more of</rdg>
+			<rdg wit="f1823">to think no more of</rdg>
+			<rdg wit="fThomas">to think no more of</rdg>
+			<rdg wit="f1831">to think no more of</rdg>
+			<rdg wit="fMS">to think no more of</rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -2674,14 +2573,17 @@
 			<rdg wit="f1823">her</rdg>
 			<rdg wit="fThomas">her</rdg>
 			<rdg wit="f1831">her</rdg>
-			<rdg wit="fMS">&lt;sga-add place="superlinear"
+		</rdgGrp>
+		<rdgGrp n="['&lt;delstart/&gt;him&lt;delend/&gt;', 'her']">
+			<rdg wit="fMS">&lt;del rend="strikethrough"
+				xml:id="c57-0033__main__d4e5486"&gt;him&lt;/del&gt; &lt;sga-add place="superlinear"
 				sID="c57-0033__main__d4e5489"/&gt;her</rdg>
 		</rdgGrp>
 	</app>
+
 	<app>
 		<rdgGrp n="['lover', '']">
-			<rdg wit="fMS">lover &lt;sga-add eID="c57-0033__main__d4e5489"/&gt;&lt;mod
-				eID="c57-0033__main__d4e5484"/&gt;</rdg>
+			<rdg wit="fMS">lover &lt;sga-add eID="c57-0033__main__d4e5489"/&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp n="['lover,']">
 			<rdg wit="f1818">&lt;pb xml:id="F1818_v2_099" n="095"/&gt;lover,</rdg>
@@ -2988,8 +2890,8 @@
 			<rdg wit="f1831">should</rdg>
 		</rdgGrp>
 		<rdgGrp
-			n="['', '&lt;delstart/&gt;would&lt;delend/&gt;', '', '&lt;delstart/&gt;was&lt;delend/&gt;', 'should']">
-			<rdg wit="fMS">&lt;mod sID="c57-0033__main__d4e5536"/&gt; &lt;del rend="strikethrough"
+			n="['&lt;delstart/&gt;would&lt;delend/&gt;', '', '&lt;delstart/&gt;was&lt;delend/&gt;', 'should']">
+			<rdg wit="fMS">&lt;del rend="strikethrough"
 				xml:id="c57-0033__main__d4e5538"&gt;would&lt;/del&gt; &lt;sga-add
 				place="superlinear" sID="c57-0033__main__d4e5541"/&gt; &lt;del rend="strikethrough"
 				xml:id="c57-0033__main__d4e5543"&gt;was&lt;/del&gt; should</rdg>
@@ -3003,10 +2905,9 @@
 			<rdg wit="fThomas">speedily be delivered</rdg>
 			<rdg wit="f1831">speedily be delivered</rdg>
 		</rdgGrp>
-		<rdgGrp n="['', '&lt;mdel&gt;b&lt;/mdel&gt;', '', 'speedily', 'be', 'delivered']">
+		<rdgGrp n="['', '', 'speedily', 'be', 'delivered']">
 			<rdg wit="fMS">&lt;sga-add eID="c57-0033__main__d4e5541"/&gt; &lt;mdel&gt;b&lt;/mdel&gt;
-				&lt;mod eID="c57-0033__main__d4e5536"/&gt; speedily &lt;lb
-				n="c57-0033__main__25"/&gt;be delivered</rdg>
+				speedily &lt;lb n="c57-0033__main__25"/&gt;be delivered</rdg>
 		</rdgGrp>
 	</app>
 
@@ -3018,9 +2919,8 @@
 			<rdg wit="f1831">up</rdg>
 		</rdgGrp>
 		<rdgGrp n="['', '', 'up']">
-			<rdg wit="fMS">&lt;mod sID="c57-0033__main__d4e5552"/&gt;&lt;sga-add place="sublinear"
-				sID="c57-0033__main__d4e5554"/&gt; &lt;metamark
-				function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
+			<rdg wit="fMS">&lt;sga-add place="sublinear" sID="c57-0033__main__d4e5554"/&gt;
+				&lt;metamark function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
 				eID="c57-0033__main__d4e5554"/&gt;&lt;sga-add hand="#pbs" place="superlinear"
 				sID="c57-0033__main__d4e5560"/&gt;up</rdg>
 		</rdgGrp>
@@ -3028,17 +2928,15 @@
 
 	<app>
 		<rdgGrp
-			n="['', 'to the french government–', 'he', 'had', 'just', 'heard', 'of', 'a', 'small', 'vessel', 'bound', 'for', 'constantinople', 'which', 'he', 'had', 'consequently', 'hired', 'a', 'vessel', 'to', 'convey', 'him', 'to', '&lt;delstart/&gt;can&lt;delend/&gt;', 'constantinople', '', '&lt;mdel&gt;in&lt;/mdel&gt;']">
-			<rdg wit="fMS">&lt;sga-add eID="c57-0033__main__d4e5560"/&gt;&lt;mod
-				eID="c57-0033__main__d4e5552"/&gt; &lt;longToken&gt;to the French
-				Government–&lt;/longToken&gt; &lt;lb n="c57-0033__main__26"/&gt;&lt;delSpan
+			n="['', 'to the french government–', 'he', 'had', 'just', 'heard', 'of', 'a', 'small', 'vessel', 'bound', 'for', 'constantinople', 'which', 'he', 'had', 'consequently', 'hired', 'a', 'vessel', 'to', 'convey', 'him', 'to', '&lt;delstart/&gt;can&lt;delend/&gt;', 'constantinople', '']">
+			<rdg wit="fMS">&lt;sga-add eID="c57-0033__main__d4e5560"/&gt; &lt;longToken&gt;to the
+				French Government–&lt;/longToken&gt; &lt;lb n="c57-0033__main__26"/&gt;&lt;delSpan
 				rend="strikethrough" spanTo="#c57-0033.04"/&gt;He had just heard of a small vessel
 				&lt;lb n="c57-0033__main__27"/&gt;bound for Constantinople which &lt;anchor
 				xml:id="c57-0033.04"/&gt;He had &lt;lb n="c57-0033__main__28"/&gt;consequently hired
 				a vessel to convey him &lt;lb n="c57-0034__main__1"/&gt;to &lt;del
 				rend="strikethrough" xml:id="c57-0034__main__d4e5585"&gt;Can&lt;/del&gt;
-				Constantinople &lt;mod sID="c57-0034__main__d4e5588"/&gt;
-				&lt;mdel&gt;in&lt;/mdel&gt;</rdg>
+				Constantinople &lt;mdel&gt;in&lt;/mdel&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp n="['to the french government; ']">
 			<rdg wit="f1818">&lt;longToken&gt;to the French government; &lt;/longToken&gt;</rdg>
@@ -3077,9 +2975,8 @@
 			<rdg wit="f1823">which city </rdg>
 			<rdg wit="fThomas">which city </rdg>
 			<rdg wit="f1831">which city </rdg>
-			<rdg wit="fMS">&lt;sga-add eID="c57-0034__main__d4e5592"/&gt;&lt;mod
-				eID="c57-0034__main__d4e5588"/&gt;which &lt;sga-add hand="#pbs" place="superlinear"
-				sID="c57-0034__main__d4e5596"/&gt;city</rdg>
+			<rdg wit="fMS">&lt;sga-add eID="c57-0034__main__d4e5592"/&gt;which &lt;sga-add
+				hand="#pbs" place="superlinear" sID="c57-0034__main__d4e5596"/&gt;city</rdg>
 		</rdgGrp>
 	</app>
 
@@ -3614,10 +3511,10 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['', '&lt;mdel&gt;50&lt;/mdel&gt;', '20', '']">
-			<rdg wit="fMS">&lt;mod sID="c57-0034__main__d4e5706"/&gt; &lt;mdel&gt;50&lt;/mdel&gt;
-				&lt;sga-add place="superlinear" sID="c57-0034__main__d4e5710"/&gt;20 &lt;sga-add
-				eID="c57-0034__main__d4e5710"/&gt;&lt;mod eID="c57-0034__main__d4e5706"/&gt;</rdg>
+		<rdgGrp n="['', '20', '']">
+			<rdg wit="fMS">&lt;mdel&gt;50&lt;/mdel&gt; &lt;sga-add place="superlinear"
+				sID="c57-0034__main__d4e5710"/&gt;20 &lt;sga-add
+				eID="c57-0034__main__d4e5710"/&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp n="['twenty']">
 			<rdg wit="f1818">twenty</rdg>
@@ -3675,9 +3572,8 @@
 			<rdg wit="f1831">dangerously</rdg>
 		</rdgGrp>
 		<rdgGrp n="['', '', 'dangerously']">
-			<rdg wit="fMS">&lt;mod sID="c57-0034__main__d4e5718"/&gt;&lt;sga-add place="sublinear"
-				sID="c57-0034__main__d4e5720"/&gt; &lt;metamark
-				function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
+			<rdg wit="fMS">&lt;sga-add place="sublinear" sID="c57-0034__main__d4e5720"/&gt;
+				&lt;metamark function="insert"&gt;^&lt;/metamark&gt; &lt;sga-add
 				eID="c57-0034__main__d4e5720"/&gt;&lt;sga-add place="superlinear"
 				sID="c57-0034__main__d4e5726"/&gt;dangerously</rdg>
 		</rdgGrp>
@@ -3685,9 +3581,9 @@
 
 	<app>
 		<rdgGrp n="['', 'ill', '&lt;delstart/&gt;and she was retarded wh&lt;delend/&gt;']">
-			<rdg wit="fMS">&lt;sga-add eID="c57-0034__main__d4e5726"/&gt;&lt;mod
-				eID="c57-0034__main__d4e5718"/&gt; ill &lt;del rend="strikethrough"
-				xml:id="c57-0034__main__d4e5730"&gt;and she was retarded wh&lt;/del&gt;</rdg>
+			<rdg wit="fMS">&lt;sga-add eID="c57-0034__main__d4e5726"/&gt; ill &lt;del
+				rend="strikethrough" xml:id="c57-0034__main__d4e5730"&gt;and she was retarded
+				wh&lt;/del&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp n="['ill.']">
 			<rdg wit="f1818">ill.</rdg>
@@ -3757,7 +3653,7 @@
 			<rdg wit="f1823">and</rdg>
 			<rdg wit="fThomas">and</rdg>
 			<rdg wit="f1831">and</rdg>
-			<rdg wit="fMS">&amp;&lt;mod sID="c57-0034__main__d4e5741"/&gt;</rdg>
+			<rdg wit="fMS">&amp;</rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -3771,8 +3667,7 @@
 			<rdg wit="fMS">&lt;del rend="strikethrough"
 				xml:id="c57-0034__main__d4e5743"&gt;Safie&lt;/del&gt; &lt;sga-add
 				place="superlinear" sID="c57-0034__main__d4e5746"/&gt;the Arabian &lt;sga-add
-				eID="c57-0034__main__d4e5746"/&gt;&lt;mod eID="c57-0034__main__d4e5741"/&gt;&lt;lb
-				n="c57-0034__main__28"/&gt;was left</rdg>
+				eID="c57-0034__main__d4e5746"/&gt;&lt;lb n="c57-0034__main__28"/&gt;was left</rdg>
 		</rdgGrp>
 	</app>
 
@@ -3894,8 +3789,7 @@
 			<rdg wit="f1831">had</rdg>
 		</rdgGrp>
 		<rdgGrp n="['', '&lt;delstart/&gt;before her death&lt;delend/&gt;', 'had']">
-			<rdg wit="fMS">&lt;lb n="c57-0035__main__5"/&gt;&lt;mod
-				sID="c57-0035__main__d4e5794"/&gt; &lt;del rend="strikethrough"
+			<rdg wit="fMS">&lt;lb n="c57-0035__main__5"/&gt; &lt;del rend="strikethrough"
 				xml:id="c57-0035__main__d4e5796"&gt;before her death&lt;/del&gt; &lt;sga-add
 				place="superlinear" sID="c57-0035__main__d4e5799"/&gt;had</rdg>
 		</rdgGrp>
@@ -3908,9 +3802,8 @@
 			<rdg wit="f1823">mentioned the name of the spot for which they were </rdg>
 			<rdg wit="fThomas">mentioned the name of the spot for which they were </rdg>
 			<rdg wit="f1831">mentioned the name of the spot for which they were </rdg>
-			<rdg wit="fMS">&lt;sga-add eID="c57-0035__main__d4e5799"/&gt;&lt;mod
-				eID="c57-0035__main__d4e5794"/&gt;mentioned the name of the &lt;lb
-				n="c57-0035__main__6"/&gt;spot for which they were</rdg>
+			<rdg wit="fMS">&lt;sga-add eID="c57-0035__main__d4e5799"/&gt;mentioned the name of the
+				&lt;lb n="c57-0035__main__6"/&gt;spot for which they were</rdg>
 		</rdgGrp>
 	</app>
 
@@ -3981,32 +3874,27 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['&lt;p-end/&gt;', '']">
-			<rdg wit="f1818">&lt;p eID="novel1_letter4_chapter13_div4_div14_p20"/&gt; &lt;milestone
-				unit="chapter" type="end" n="13"/&gt;</rdg>
-			<rdg wit="f1823">&lt;p eID="novel1_letter4_chapter13_div4_div14_p20"/&gt; &lt;milestone
-				unit="chapter" type="end" n="13"/&gt;</rdg>
-			<rdg wit="fThomas">&lt;p eID="novel1_letter4_chapter13_div4_div14_p18"/&gt;
-				&lt;milestone unit="chapter" type="end" n="13"/&gt;</rdg>
-			<rdg wit="f1831">&lt;p eID="novel1_letter4_chapter14_div4_div14_p20"/&gt; &lt;milestone
-				unit="chapter" type="end" n="14"/&gt;</rdg>
+		<rdgGrp n="['&lt;p-end/&gt;']">
+			<rdg wit="f1818">&lt;p eID="novel1_letter4_chapter13_div4_div14_p20"/&gt;</rdg>
+			<rdg wit="f1823">&lt;p eID="novel1_letter4_chapter13_div4_div14_p20"/&gt;</rdg>
+			<rdg wit="fThomas">&lt;p eID="novel1_letter4_chapter13_div4_div14_p18"/&gt;</rdg>
+			<rdg wit="f1831">&lt;p eID="novel1_letter4_chapter14_div4_div14_p20"/&gt;</rdg>
 		</rdgGrp>
 		<rdgGrp
 			n="['having overcome many difficulties succeeded at length in joining her lover in his retreat ']">
 			<rdg wit="fMS">&lt;longToken&gt;&lt;delSpan rend="strikethrough"
 				spanTo="#c57-0037.01"/&gt;having overcome many difficulties succeeded &lt;lb
-				n="c57-0037__main__2"/&gt;at length in joining her lover in his retreat &lt;anchor
-				xml:id="c57-0037.01"/&gt;&lt;/longToken&gt;</rdg>
+				n="c57-0037__main__2"/&gt;at length in joining her lover in his retreat</rdg>
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['']">
-			<rdg wit="f1818"/>
-			<rdg wit="f1823"/>
-			<rdg wit="fThomas"/>
-			<rdg wit="f1831"/>
-			<rdg wit="fMS"/>
+		<rdgGrp n="['', '']">
+			<rdg wit="f1818">&lt;milestone unit="chapter" type="end" n="13"/&gt;</rdg>
+			<rdg wit="f1823">&lt;milestone unit="chapter" type="end" n="13"/&gt;</rdg>
+			<rdg wit="fThomas">&lt;milestone unit="chapter" type="end" n="13"/&gt;</rdg>
+			<rdg wit="f1831">&lt;milestone unit="chapter" type="end" n="14"/&gt;</rdg>
+			<rdg wit="fMS">&lt;anchor xml:id="c57-0037.01"/&gt;&lt;/longToken&gt;</rdg>
 		</rdgGrp>
 	</app>
 </cx:apparatus>
-<!-- 2023-03-16 18:54:06.132637 -->
+<!-- 2023-03-16 04:45:53.915302 -->

--- a/collationChunks/C20/output/Collation_C20-partway.xml
+++ b/collationChunks/C20/output/Collation_C20-partway.xml
@@ -49,8 +49,8 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['&lt;delstart/&gt;became informed&lt;delend/&gt;', '', '&lt;delstart/&gt; of th &lt;delend/&gt;', '', '', '', '']">
-			<rdg wit="fMS">&lt;del next=&quot;#c57-0031.02&quot; rend=&quot;strikethrough&quot; xml:id=&quot;c57-0031__main__d4e4832&quot;&gt;became informed&lt;/del&gt; &lt;lb n=&quot;c57-0031__main__3&quot;/&gt;&lt;anchor xml:id=&quot;c57-0031.03&quot;/&gt;&lt;lb n=&quot;c57-0031__left_margin__1&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0031__left_margin__d4e4843&quot;&gt; of th &lt;/del&gt; &lt;anchor xml:id=&quot;c57-0031.01&quot;/&gt; &lt;mdel&gt;of&lt;/mdel&gt; &lt;sga-add place=&quot;sublinear&quot; sID=&quot;c57-0031__main__d4e4853&quot;/&gt; &lt;metamark function=&quot;insert&quot;&gt;^&lt;/metamark&gt; </rdg>
+		<rdgGrp n="['&lt;delstart/&gt;became informed&lt;delend/&gt;', '', '&lt;delstart/&gt; of th &lt;delend/&gt;', '', '&lt;mdel&gt;of&lt;/mdel&gt;', '', '']">
+			<rdg wit="fMS">&lt;del next=&quot;#c57-0031.02&quot; rend=&quot;strikethrough&quot; xml:id=&quot;c57-0031__main__d4e4832&quot;&gt;became informed&lt;/del&gt; &lt;lb n=&quot;c57-0031__main__3&quot;/&gt;&lt;anchor xml:id=&quot;c57-0031.03&quot;/&gt;&lt;lb n=&quot;c57-0031__left_margin__1&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0031__left_margin__d4e4843&quot;&gt; of th &lt;/del&gt; &lt;anchor xml:id=&quot;c57-0031.01&quot;/&gt;&lt;mod sID=&quot;c57-0031__main__d4e4849&quot;/&gt; &lt;mdel&gt;of&lt;/mdel&gt; &lt;sga-add place=&quot;sublinear&quot; sID=&quot;c57-0031__main__d4e4853&quot;/&gt; &lt;metamark function=&quot;insert&quot;&gt;^&lt;/metamark&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -64,7 +64,7 @@
 	</app>
 	<app>
 		<rdgGrp n="['']">
-			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0031__main__d4e4859&quot;/&gt; </rdg>
+			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0031__main__d4e4859&quot;/&gt;&lt;mod eID=&quot;c57-0031__main__d4e4849&quot;/&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -91,8 +91,8 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['']">
-			<rdg wit="fMS">&lt;mdel&gt;in&lt;/mdel&gt; </rdg>
+		<rdgGrp n="['', '&lt;mdel&gt;in&lt;/mdel&gt;']">
+			<rdg wit="fMS">&lt;mod sID=&quot;c57-0031__main__d4e4881&quot;/&gt; &lt;mdel&gt;in&lt;/mdel&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -106,7 +106,7 @@
 	</app>
 	<app>
 		<rdgGrp n="['']">
-			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0031__main__d4e4885&quot;/&gt; </rdg>
+			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0031__main__d4e4885&quot;/&gt;&lt;mod eID=&quot;c57-0031__main__d4e4881&quot;/&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -313,8 +313,8 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['']">
-			<rdg wit="fMS">&lt;mdel&gt;t&lt;/mdel&gt; </rdg>
+		<rdgGrp n="['', '&lt;mdel&gt;t&lt;/mdel&gt;']">
+			<rdg wit="fMS">&lt;mod sID=&quot;c57-0031__main__d4e4939&quot;/&gt; &lt;mdel&gt;t&lt;/mdel&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -323,7 +323,7 @@
 			<rdg wit="f1823">in the ser&lt;pb xml:id=&quot;F1823_v2_290&quot; n=&quot;17&quot;/&gt;vice of his </rdg>
 			<rdg wit="fThomas">in the ser&lt;pb xml:id=&quot;F1818_v2_089&quot; n=&quot;085&quot;/&gt;vice of his </rdg>
 			<rdg wit="f1831">in the service of his </rdg>
-			<rdg wit="fMS">&lt;sga-add place=&quot;intralinear&quot; sID=&quot;c57-0031__main__d4e4943&quot;/&gt;i&lt;sga-add eID=&quot;c57-0031__main__d4e4943&quot;/&gt;n the service of his </rdg>
+			<rdg wit="fMS">&lt;sga-add place=&quot;intralinear&quot; sID=&quot;c57-0031__main__d4e4943&quot;/&gt;i&lt;sga-add eID=&quot;c57-0031__main__d4e4943&quot;/&gt;&lt;mod eID=&quot;c57-0031__main__d4e4939&quot;/&gt;n the service of his </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -347,8 +347,8 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['&lt;delstart/&gt;been&lt;delend/&gt;']">
-			<rdg wit="fMS">&lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0031__main__d4e4951&quot;&gt;been&lt;/del&gt; </rdg>
+		<rdgGrp n="['', '&lt;delstart/&gt;been&lt;delend/&gt;']">
+			<rdg wit="fMS">&lt;mod sID=&quot;c57-0031__main__d4e4949&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0031__main__d4e4951&quot;&gt;been&lt;/del&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -376,7 +376,7 @@
 	</app>
 	<app>
 		<rdgGrp n="['']">
-			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0031__main__d4e4963&quot;/&gt; </rdg>
+			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0031__main__d4e4963&quot;/&gt;&lt;mod eID=&quot;c57-0031__main__d4e4949&quot;/&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -477,8 +477,8 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['that', '&lt;delstart/&gt;that&lt;delend/&gt;']">
-			<rdg wit="fMS">that &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0031__main__d4e4994&quot;&gt;that&lt;/del&gt; </rdg>
+		<rdgGrp n="['that', '', '&lt;delstart/&gt;that&lt;delend/&gt;']">
+			<rdg wit="fMS">that &lt;mod sID=&quot;c57-0031__main__d4e4992&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0031__main__d4e4994&quot;&gt;that&lt;/del&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -492,7 +492,7 @@
 	</app>
 	<app>
 		<rdgGrp n="['', 'virtue', '', '', 'and']">
-			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0031__main__d4e4997&quot;/&gt; virtue &lt;sga-add place=&quot;sublinear&quot; sID=&quot;c57-0031__main__d4e5003&quot;/&gt; &lt;metamark function=&quot;insert&quot;&gt;^&lt;/metamark&gt; &lt;sga-add eID=&quot;c57-0031__main__d4e5003&quot;/&gt;&lt;sga-add hand=&quot;#pbs&quot; next=&quot;#c57-0031.10&quot; place=&quot;superlinear&quot; sID=&quot;c57-0031__main__d4e5009&quot;/&gt;&amp; </rdg>
+			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0031__main__d4e4997&quot;/&gt;&lt;mod eID=&quot;c57-0031__main__d4e4992&quot;/&gt; virtue &lt;mod sID=&quot;c57-0031__main__d4e5001&quot;/&gt;&lt;sga-add place=&quot;sublinear&quot; sID=&quot;c57-0031__main__d4e5003&quot;/&gt; &lt;metamark function=&quot;insert&quot;&gt;^&lt;/metamark&gt; &lt;sga-add eID=&quot;c57-0031__main__d4e5003&quot;/&gt;&lt;sga-add hand=&quot;#pbs&quot; next=&quot;#c57-0031.10&quot; place=&quot;superlinear&quot; sID=&quot;c57-0031__main__d4e5009&quot;/&gt;&amp; </rdg>
 		</rdgGrp>
 		<rdgGrp n="['virtue,']">
 			<rdg wit="f1818">virtue, </rdg>
@@ -527,7 +527,7 @@
 			<rdg wit="f1823">taste, accompanied </rdg>
 			<rdg wit="fThomas">taste, accompanied </rdg>
 			<rdg wit="f1831">taste, accompanied </rdg>
-			<rdg wit="fMS">taste, &lt;sga-add eID=&quot;c57-0031__main__d4e5009&quot;/&gt;&lt;w ana=&quot;start&quot;/&gt;ac&lt;lb n=&quot;c57-0031__main__20&quot;/&gt;companied&lt;w ana=&quot;end&quot;/&gt; </rdg>
+			<rdg wit="fMS">taste, &lt;sga-add eID=&quot;c57-0031__main__d4e5009&quot;/&gt;&lt;mod eID=&quot;c57-0031__main__d4e5001&quot;/&gt;&lt;w ana=&quot;start&quot;/&gt;ac&lt;lb n=&quot;c57-0031__main__20&quot;/&gt;companied&lt;w ana=&quot;end&quot;/&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -591,8 +591,8 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['&lt;delstart/&gt;was&lt;delend/&gt;']">
-			<rdg wit="fMS">&lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0031__main__d4e5029&quot;&gt;was&lt;/del&gt; </rdg>
+		<rdgGrp n="['', '&lt;delstart/&gt;was&lt;delend/&gt;']">
+			<rdg wit="fMS">&lt;mod sID=&quot;c57-0031__main__d4e5027&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0031__main__d4e5029&quot;&gt;was&lt;/del&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -606,7 +606,7 @@
 	</app>
 	<app>
 		<rdgGrp n="['']">
-			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0031__main__d4e5032&quot;/&gt; </rdg>
+			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0031__main__d4e5032&quot;/&gt;&lt;mod eID=&quot;c57-0031__main__d4e5027&quot;/&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -620,7 +620,7 @@
 	</app>
 	<app>
 		<rdgGrp n="['', '&lt;delstart/&gt;fall&lt;delend/&gt;', 'ruin;', '']">
-			<rdg wit="fMS">&lt;lb n=&quot;c57-0031__main__23&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0031__main__d4e5040&quot;&gt;fall&lt;/del&gt; &lt;sga-add hand=&quot;#pbs&quot; place=&quot;superlinear&quot; sID=&quot;c57-0031__main__d4e5043&quot;/&gt;ruin; &lt;sga-add eID=&quot;c57-0031__main__d4e5043&quot;/&gt; </rdg>
+			<rdg wit="fMS">&lt;lb n=&quot;c57-0031__main__23&quot;/&gt;&lt;mod sID=&quot;c57-0031__main__d4e5038&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0031__main__d4e5040&quot;&gt;fall&lt;/del&gt; &lt;sga-add hand=&quot;#pbs&quot; place=&quot;superlinear&quot; sID=&quot;c57-0031__main__d4e5043&quot;/&gt;ruin; &lt;sga-add eID=&quot;c57-0031__main__d4e5043&quot;/&gt;&lt;mod eID=&quot;c57-0031__main__d4e5038&quot;/&gt; </rdg>
 		</rdgGrp>
 		<rdgGrp n="['ruin.']">
 			<rdg wit="f1818">ruin. </rdg>
@@ -639,8 +639,8 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['']">
-			<rdg wit="fMS">&lt;mdel&gt;t&lt;/mdel&gt; </rdg>
+		<rdgGrp n="['', '&lt;mdel&gt;t&lt;/mdel&gt;']">
+			<rdg wit="fMS">&lt;mod sID=&quot;c57-0031__main__d4e5047&quot;/&gt; &lt;mdel&gt;t&lt;/mdel&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -649,7 +649,7 @@
 			<rdg wit="f1823">Turkish </rdg>
 			<rdg wit="fThomas">Turkish </rdg>
 			<rdg wit="f1831">Turkish </rdg>
-			<rdg wit="fMS">&lt;sga-add place=&quot;intralinear&quot; sID=&quot;c57-0031__main__d4e5051&quot;/&gt;T&lt;sga-add eID=&quot;c57-0031__main__d4e5051&quot;/&gt;urkish </rdg>
+			<rdg wit="fMS">&lt;sga-add place=&quot;intralinear&quot; sID=&quot;c57-0031__main__d4e5051&quot;/&gt;T&lt;sga-add eID=&quot;c57-0031__main__d4e5051&quot;/&gt;&lt;mod eID=&quot;c57-0031__main__d4e5047&quot;/&gt;urkish </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -693,8 +693,8 @@
 			<rdg wit="fThomas">years, when, </rdg>
 			<rdg wit="f1831">years, when, </rdg>
 		</rdgGrp>
-		<rdgGrp n="['years.', 'when', 'his', 'person', 'became', '&lt;delstart/&gt;for some&lt;delend/&gt;', '', '']">
-			<rdg wit="fMS">years. When his person &lt;lb n=&quot;c57-0031__main__25&quot;/&gt;became &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0031__main__d4e5065&quot;&gt;for some&lt;/del&gt; &lt;sga-add place=&quot;sublinear&quot; sID=&quot;c57-0031__main__d4e5068&quot;/&gt; &lt;metamark function=&quot;insert&quot;&gt;^&lt;/metamark&gt; </rdg>
+		<rdgGrp n="['years.', 'when', 'his', 'person', 'became', '', '&lt;delstart/&gt;for some&lt;delend/&gt;', '', '']">
+			<rdg wit="fMS">years. When his person &lt;lb n=&quot;c57-0031__main__25&quot;/&gt;became &lt;mod sID=&quot;c57-0031__main__d4e5063&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0031__main__d4e5065&quot;&gt;for some&lt;/del&gt; &lt;sga-add place=&quot;sublinear&quot; sID=&quot;c57-0031__main__d4e5068&quot;/&gt; &lt;metamark function=&quot;insert&quot;&gt;^&lt;/metamark&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -708,7 +708,7 @@
 	</app>
 	<app>
 		<rdgGrp n="['learn', '']">
-			<rdg wit="fMS">learn &lt;sga-add eID=&quot;c57-0031__main__d4e5074&quot;/&gt; </rdg>
+			<rdg wit="fMS">learn &lt;sga-add eID=&quot;c57-0031__main__d4e5074&quot;/&gt;&lt;mod eID=&quot;c57-0031__main__d4e5063&quot;/&gt; </rdg>
 		</rdgGrp>
 		<rdgGrp n="['learn,', 'he', 'became']">
 			<rdg wit="f1818">learn, he became </rdg>
@@ -828,7 +828,7 @@
 	</app>
 	<app>
 		<rdgGrp n="['wealth', '', '&lt;delstart/&gt;had been the causes of his condemnation rather&lt;delend/&gt;', '', '&lt;delstart/&gt;than&lt;delend/&gt;']">
-			<rdg wit="fMS">wealth &lt;lb n=&quot;c57-0031__main__32&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0031__main__d4e5105&quot;&gt;had been the causes of his condemnation rather&lt;/del&gt; &lt;lb n=&quot;c57-0032__main__1&quot;/&gt;&lt;anchor xml:id=&quot;c57-0032.01&quot;/&gt;&lt;lb n=&quot;c57-0032__left_margin__1&quot;/&gt; &lt;del rend=&quot;smear&quot; xml:id=&quot;c57-0032__left_margin__d4e5126&quot;&gt;than&lt;/del&gt; </rdg>
+			<rdg wit="fMS">wealth &lt;lb n=&quot;c57-0031__main__32&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0031__main__d4e5105&quot;&gt;had been the causes of his condemnation rather&lt;/del&gt; &lt;lb n=&quot;c57-0032__main__1&quot;/&gt;&lt;mod sID=&quot;c57-0032__main__d4e5118&quot;/&gt;&lt;anchor xml:id=&quot;c57-0032.01&quot;/&gt;&lt;lb n=&quot;c57-0032__left_margin__1&quot;/&gt; &lt;del rend=&quot;smear&quot; xml:id=&quot;c57-0032__left_margin__d4e5126&quot;&gt;than&lt;/del&gt; </rdg>
 		</rdgGrp>
 		<rdgGrp n="['wealth,']">
 			<rdg wit="f1818">wealth, </rdg>
@@ -848,7 +848,7 @@
 	</app>
 	<app>
 		<rdgGrp n="['']">
-			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0032__main__d4e5133&quot;/&gt; </rdg>
+			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0032__main__d4e5133&quot;/&gt;&lt;mod eID=&quot;c57-0032__main__d4e5118&quot;/&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -933,8 +933,8 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['', '', 'w', '', 'ere', '', 'uncontrolable']">
-			<rdg wit="fMS">&lt;sga-add place=&quot;sublinear&quot; sID=&quot;c57-0032__main__d4e5165&quot;/&gt; &lt;metamark function=&quot;insert&quot;&gt;^&lt;/metamark&gt; &lt;sga-add eID=&quot;c57-0032__main__d4e5165&quot;/&gt;&lt;sga-add place=&quot;superlinear&quot; sID=&quot;c57-0032__main__d4e5171&quot;/&gt;w &lt;mdel&gt;as&lt;/mdel&gt; &lt;sga-add hand=&quot;#pbs&quot; place=&quot;intralinear&quot; sID=&quot;c57-0032__main__d4e5177&quot;/&gt;ere &lt;sga-add eID=&quot;c57-0032__main__d4e5177&quot;/&gt;&lt;sga-add eID=&quot;c57-0032__main__d4e5171&quot;/&gt; uncontrolable </rdg>
+		<rdgGrp n="['', '', 'w', '&lt;mdel&gt;as&lt;/mdel&gt;', 'ere', '', 'uncontrolable']">
+			<rdg wit="fMS">&lt;mod sID=&quot;c57-0032__main__d4e5163&quot;/&gt;&lt;sga-add place=&quot;sublinear&quot; sID=&quot;c57-0032__main__d4e5165&quot;/&gt; &lt;metamark function=&quot;insert&quot;&gt;^&lt;/metamark&gt; &lt;sga-add eID=&quot;c57-0032__main__d4e5165&quot;/&gt;&lt;sga-add place=&quot;superlinear&quot; sID=&quot;c57-0032__main__d4e5171&quot;/&gt;w&lt;mod sID=&quot;c57-0032__main__d4e5173&quot;/&gt; &lt;mdel&gt;as&lt;/mdel&gt; &lt;sga-add hand=&quot;#pbs&quot; place=&quot;intralinear&quot; sID=&quot;c57-0032__main__d4e5177&quot;/&gt;ere &lt;sga-add eID=&quot;c57-0032__main__d4e5177&quot;/&gt;&lt;mod eID=&quot;c57-0032__main__d4e5173&quot;/&gt;&lt;sga-add eID=&quot;c57-0032__main__d4e5171&quot;/&gt;&lt;mod eID=&quot;c57-0032__main__d4e5163&quot;/&gt; uncontrolable </rdg>
 		</rdgGrp>
 		<rdgGrp n="['were', 'uncontrollable,']">
 			<rdg wit="f1818">were uncontrollable, </rdg>
@@ -953,8 +953,8 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['', '&lt;delstart/&gt;event.&lt;delend/&gt;', '', '']">
-			<rdg wit="fMS">&lt;lb n=&quot;c57-0032__main__4&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0032__main__d4e5187&quot;&gt;event.&lt;/del&gt; &lt;sga-add hand=&quot;#pbs&quot; place=&quot;superlinear&quot; sID=&quot;c57-0032__main__d4e5190&quot;/&gt; &lt;mdel&gt;of&lt;/mdel&gt; </rdg>
+		<rdgGrp n="['', '&lt;delstart/&gt;event.&lt;delend/&gt;', '', '&lt;mdel&gt;of&lt;/mdel&gt;']">
+			<rdg wit="fMS">&lt;lb n=&quot;c57-0032__main__4&quot;/&gt;&lt;mod sID=&quot;c57-0032__main__d4e5185&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0032__main__d4e5187&quot;&gt;event.&lt;/del&gt; &lt;sga-add hand=&quot;#pbs&quot; place=&quot;superlinear&quot; sID=&quot;c57-0032__main__d4e5190&quot;/&gt; &lt;mdel&gt;of&lt;/mdel&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -968,7 +968,7 @@
 	</app>
 	<app>
 		<rdgGrp n="['']">
-			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0032__main__d4e5190&quot;/&gt; </rdg>
+			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0032__main__d4e5190&quot;/&gt;&lt;mod eID=&quot;c57-0032__main__d4e5185&quot;/&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -1042,7 +1042,7 @@
 	</app>
 	<app>
 		<rdgGrp n="['prison', '&lt;delstart/&gt;goal&lt;delend/&gt;', 'prison', '']">
-			<rdg wit="fMS">&lt;delSpan rend=&quot;strikethrough&quot; spanTo=&quot;#c57-0032.04&quot;/&gt;&lt;w ana=&quot;start&quot;/&gt;pri&lt;lb n=&quot;c57-0032__main__8&quot;/&gt;son&lt;w ana=&quot;end&quot;/&gt;&lt;anchor xml:id=&quot;c57-0032.04&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0032__main__d4e5216&quot;&gt;goal&lt;/del&gt; &lt;sga-add hand=&quot;#pbs&quot; place=&quot;superlinear&quot; sID=&quot;c57-0032__main__d4e5219&quot;/&gt;prison &lt;sga-add eID=&quot;c57-0032__main__d4e5219&quot;/&gt; </rdg>
+			<rdg wit="fMS">&lt;delSpan rend=&quot;strikethrough&quot; spanTo=&quot;#c57-0032.04&quot;/&gt;&lt;w ana=&quot;start&quot;/&gt;pri&lt;lb n=&quot;c57-0032__main__8&quot;/&gt;son&lt;w ana=&quot;end&quot;/&gt;&lt;anchor xml:id=&quot;c57-0032.04&quot;/&gt;&lt;mod sID=&quot;c57-0032__main__d4e5214&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0032__main__d4e5216&quot;&gt;goal&lt;/del&gt; &lt;sga-add hand=&quot;#pbs&quot; place=&quot;superlinear&quot; sID=&quot;c57-0032__main__d4e5219&quot;/&gt;prison &lt;sga-add eID=&quot;c57-0032__main__d4e5219&quot;/&gt;&lt;mod eID=&quot;c57-0032__main__d4e5214&quot;/&gt; </rdg>
 		</rdgGrp>
 		<rdgGrp n="['prison,']">
 			<rdg wit="f1818">prison, </rdg>
@@ -1062,7 +1062,7 @@
 	</app>
 	<app>
 		<rdgGrp n="['st', '', '', 'r', '', 'ongly']">
-			<rdg wit="fMS">st &lt;sga-add place=&quot;sublinear&quot; sID=&quot;c57-0032__main__d4e5225&quot;/&gt; &lt;metamark function=&quot;insert&quot;&gt;^&lt;/metamark&gt; &lt;sga-add eID=&quot;c57-0032__main__d4e5225&quot;/&gt;&lt;sga-add place=&quot;superlinear&quot; sID=&quot;c57-0032__main__d4e5231&quot;/&gt;r &lt;sga-add eID=&quot;c57-0032__main__d4e5231&quot;/&gt; ongly </rdg>
+			<rdg wit="fMS">st &lt;mod sID=&quot;c57-0032__main__d4e5223&quot;/&gt;&lt;sga-add place=&quot;sublinear&quot; sID=&quot;c57-0032__main__d4e5225&quot;/&gt; &lt;metamark function=&quot;insert&quot;&gt;^&lt;/metamark&gt; &lt;sga-add eID=&quot;c57-0032__main__d4e5225&quot;/&gt;&lt;sga-add place=&quot;superlinear&quot; sID=&quot;c57-0032__main__d4e5231&quot;/&gt;r &lt;sga-add eID=&quot;c57-0032__main__d4e5231&quot;/&gt;&lt;mod eID=&quot;c57-0032__main__d4e5223&quot;/&gt; ongly </rdg>
 		</rdgGrp>
 		<rdgGrp n="['strongly']">
 			<rdg wit="f1818">strongly </rdg>
@@ -1081,8 +1081,8 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['&lt;delstart/&gt;prison&lt;delend/&gt;']">
-			<rdg wit="fMS">&lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0032__main__d4e5239&quot;&gt;prison&lt;/del&gt; </rdg>
+		<rdgGrp n="['', '&lt;delstart/&gt;prison&lt;delend/&gt;']">
+			<rdg wit="fMS">&lt;mod sID=&quot;c57-0032__main__d4e5237&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0032__main__d4e5239&quot;&gt;prison&lt;/del&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -1091,7 +1091,7 @@
 			<rdg wit="f1823">building, which </rdg>
 			<rdg wit="fThomas">building, which </rdg>
 			<rdg wit="f1831">building, which </rdg>
-			<rdg wit="fMS">&lt;sga-add hand=&quot;#pbs&quot; place=&quot;superlinear&quot; sID=&quot;c57-0032__main__d4e5242&quot;/&gt;building, &lt;sga-add eID=&quot;c57-0032__main__d4e5242&quot;/&gt;&lt;lb n=&quot;c57-0032__main__10&quot;/&gt;which </rdg>
+			<rdg wit="fMS">&lt;sga-add hand=&quot;#pbs&quot; place=&quot;superlinear&quot; sID=&quot;c57-0032__main__d4e5242&quot;/&gt;building, &lt;sga-add eID=&quot;c57-0032__main__d4e5242&quot;/&gt;&lt;mod eID=&quot;c57-0032__main__d4e5237&quot;/&gt;&lt;lb n=&quot;c57-0032__main__10&quot;/&gt;which </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -1223,8 +1223,8 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['&lt;delstart/&gt;warm&lt;delend/&gt;']">
-			<rdg wit="fMS">&lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0032__main__d4e5283&quot;&gt;warm&lt;/del&gt; </rdg>
+		<rdgGrp n="['', '&lt;delstart/&gt;warm&lt;delend/&gt;']">
+			<rdg wit="fMS">&lt;mod sID=&quot;c57-0032__main__d4e5281&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0032__main__d4e5283&quot;&gt;warm&lt;/del&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -1233,7 +1233,7 @@
 			<rdg wit="f1823">kindle the zeal of his </rdg>
 			<rdg wit="fThomas">kindle the zeal of his </rdg>
 			<rdg wit="f1831">kindle the zeal of his </rdg>
-			<rdg wit="fMS">&lt;anchor xml:id=&quot;c57-0032.05&quot;/&gt;&lt;lb n=&quot;c57-0032__left_margin__1&quot;/&gt;&lt;sga-add hand=&quot;#pbs&quot; sID=&quot;c57-0032__left_margin__d4e5292&quot;/&gt;kindle &lt;sga-add eID=&quot;c57-0032__left_margin__d4e5292&quot;/&gt;&lt;lb n=&quot;c57-0032__main__18&quot;/&gt;the zeal of his </rdg>
+			<rdg wit="fMS">&lt;anchor xml:id=&quot;c57-0032.05&quot;/&gt;&lt;lb n=&quot;c57-0032__left_margin__1&quot;/&gt;&lt;sga-add hand=&quot;#pbs&quot; sID=&quot;c57-0032__left_margin__d4e5292&quot;/&gt;kindle &lt;sga-add eID=&quot;c57-0032__left_margin__d4e5292&quot;/&gt;&lt;mod eID=&quot;c57-0032__main__d4e5281&quot;/&gt;&lt;lb n=&quot;c57-0032__main__18&quot;/&gt;the zeal of his </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -1371,8 +1371,8 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['', '', '', '&lt;delstart/&gt;', '       altho it had not', '               en ', '   &lt;delend/&gt;']">
-			<rdg wit="fMS">&lt;sga-add place=&quot;sublinear&quot; sID=&quot;c57-0032__main__d4e5325&quot;/&gt; &lt;metamark function=&quot;insert&quot;&gt;^&lt;/metamark&gt; &lt;sga-add eID=&quot;c57-0032__main__d4e5325&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0032__main__d4e5331&quot;&gt;        &lt;sga-add hand=&quot;#pbs&quot; place=&quot;superlinear&quot; sID=&quot;c57-0032__main__d4e5333&quot;/&gt;altho it had not                en &lt;sga-add eID=&quot;c57-0032__main__d4e5333&quot;/&gt;    &lt;/del&gt; </rdg>
+		<rdgGrp n="['', '', '', '&lt;delstart/&gt;', '       altho it had not', '               en ', '   &lt;delend/&gt;', '']">
+			<rdg wit="fMS">&lt;mod sID=&quot;c57-0032__main__d4e5323&quot;/&gt;&lt;sga-add place=&quot;sublinear&quot; sID=&quot;c57-0032__main__d4e5325&quot;/&gt; &lt;metamark function=&quot;insert&quot;&gt;^&lt;/metamark&gt; &lt;sga-add eID=&quot;c57-0032__main__d4e5325&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0032__main__d4e5331&quot;&gt;        &lt;sga-add hand=&quot;#pbs&quot; place=&quot;superlinear&quot; sID=&quot;c57-0032__main__d4e5333&quot;/&gt;altho it had not                en &lt;sga-add eID=&quot;c57-0032__main__d4e5333&quot;/&gt;    &lt;/del&gt; &lt;mod eID=&quot;c57-0032__main__d4e5323&quot;/&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -1445,8 +1445,8 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['&lt;delstart/&gt;re ', '&lt;mod sid=&quot;c57-0033__main__d4e5375&quot;/&gt;', '      &lt;mdel&gt;', '                  &lt;/mdel&gt;', '       s ', '      &lt;mod eid=&quot;c57-0033__main__d4e5375&quot;/&gt; olved&lt;delend/&gt;', 'endeavored']">
-			<rdg wit="fMS">&lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0033__main__d4e5373&quot;&gt;re  &lt;mod sID=&quot;c57-0033__main__d4e5375&quot;/&gt;       &lt;mdel&gt;                   &lt;/mdel&gt;        &lt;sga-add place=&quot;intralinear&quot; sID=&quot;c57-0033__main__d4e5382&quot;/&gt;s &lt;sga-add eID=&quot;c57-0033__main__d4e5382&quot;/&gt;       &lt;mod eID=&quot;c57-0033__main__d4e5375&quot;/&gt; olved&lt;/del&gt; &lt;anchor xml:id=&quot;c57-0033.02&quot;/&gt;&lt;lb n=&quot;c57-0033__left_margin__1&quot;/&gt;&lt;sga-add sID=&quot;c57-0033__left_margin__d4e5393&quot;/&gt;endeavored </rdg>
+		<rdgGrp n="['', '&lt;delstart/&gt;re ', '', '      &lt;mdel&gt;', '                  &lt;/mdel&gt;', '       s ', '       olved&lt;delend/&gt;', 'endeavored']">
+			<rdg wit="fMS">&lt;mod sID=&quot;c57-0033__main__d4e5371&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0033__main__d4e5373&quot;&gt;re  &lt;mod sID=&quot;c57-0033__main__d4e5375&quot;/&gt;       &lt;mdel&gt;                   &lt;/mdel&gt;        &lt;sga-add place=&quot;intralinear&quot; sID=&quot;c57-0033__main__d4e5382&quot;/&gt;s &lt;sga-add eID=&quot;c57-0033__main__d4e5382&quot;/&gt;       &lt;mod eID=&quot;c57-0033__main__d4e5375&quot;/&gt; olved&lt;/del&gt; &lt;anchor xml:id=&quot;c57-0033.02&quot;/&gt;&lt;lb n=&quot;c57-0033__left_margin__1&quot;/&gt;&lt;sga-add sID=&quot;c57-0033__left_margin__d4e5393&quot;/&gt;endeavored </rdg>
 		</rdgGrp>
 		<rdgGrp n="['endeavoured']">
 			<rdg wit="f1818">endeavoured </rdg>
@@ -1461,7 +1461,7 @@
 			<rdg wit="f1823">to secure </rdg>
 			<rdg wit="fThomas">to secure </rdg>
 			<rdg wit="f1831">to secure </rdg>
-			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0033__left_margin__d4e5393&quot;/&gt;&lt;lb n=&quot;c57-0033__main__3&quot;/&gt;to secure </rdg>
+			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0033__left_margin__d4e5393&quot;/&gt;&lt;mod eID=&quot;c57-0033__main__d4e5371&quot;/&gt;&lt;lb n=&quot;c57-0033__main__3&quot;/&gt;to secure </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -1479,8 +1479,8 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['&lt;delstart/&gt;at any pr&lt;delend/&gt;', '', '']">
-			<rdg wit="fMS">&lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0033__main__d4e5407&quot;&gt;at any pr&lt;/del&gt; &lt;sga-add place=&quot;sublinear&quot; sID=&quot;c57-0033__main__d4e5410&quot;/&gt; &lt;metamark function=&quot;insert&quot;&gt;^&lt;/metamark&gt; </rdg>
+		<rdgGrp n="['', '&lt;delstart/&gt;at any pr&lt;delend/&gt;', '', '']">
+			<rdg wit="fMS">&lt;mod sID=&quot;c57-0033__main__d4e5405&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0033__main__d4e5407&quot;&gt;at any pr&lt;/del&gt; &lt;sga-add place=&quot;sublinear&quot; sID=&quot;c57-0033__main__d4e5410&quot;/&gt; &lt;metamark function=&quot;insert&quot;&gt;^&lt;/metamark&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -1489,7 +1489,7 @@
 			<rdg wit="f1823">more entirely </rdg>
 			<rdg wit="fThomas">more entirely </rdg>
 			<rdg wit="f1831">more entirely </rdg>
-			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0033__main__d4e5410&quot;/&gt;&lt;sga-add place=&quot;superlinear&quot; sID=&quot;c57-0033__main__d4e5416&quot;/&gt;more entirely&lt;sga-add eID=&quot;c57-0033__main__d4e5416&quot;/&gt; </rdg>
+			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0033__main__d4e5410&quot;/&gt;&lt;sga-add place=&quot;superlinear&quot; sID=&quot;c57-0033__main__d4e5416&quot;/&gt;more entirely&lt;sga-add eID=&quot;c57-0033__main__d4e5416&quot;/&gt;&lt;mod eID=&quot;c57-0033__main__d4e5405&quot;/&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -1530,8 +1530,8 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['&lt;delstart/&gt;', '       offer ', '   &lt;delend/&gt;', 'offer', '']">
-			<rdg wit="fMS">&lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0033__main__d4e5427&quot;&gt;        &lt;sga-add hand=&quot;#pbs&quot; place=&quot;superlinear&quot; sID=&quot;c57-0033__main__d4e5429&quot;/&gt;offer &lt;sga-add eID=&quot;c57-0033__main__d4e5429&quot;/&gt;    &lt;/del&gt; &lt;sga-add hand=&quot;#pbs&quot; place=&quot;superlinear&quot; sID=&quot;c57-0033__main__d4e5439&quot;/&gt;offer &lt;sga-add eID=&quot;c57-0033__main__d4e5439&quot;/&gt; </rdg>
+		<rdgGrp n="['', '&lt;delstart/&gt;', '       offer ', '   &lt;delend/&gt;', 'offer', '']">
+			<rdg wit="fMS">&lt;mod sID=&quot;c57-0033__main__d4e5425&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0033__main__d4e5427&quot;&gt;        &lt;sga-add hand=&quot;#pbs&quot; place=&quot;superlinear&quot; sID=&quot;c57-0033__main__d4e5429&quot;/&gt;offer &lt;sga-add eID=&quot;c57-0033__main__d4e5429&quot;/&gt;    &lt;/del&gt; &lt;sga-add hand=&quot;#pbs&quot; place=&quot;superlinear&quot; sID=&quot;c57-0033__main__d4e5439&quot;/&gt;offer &lt;sga-add eID=&quot;c57-0033__main__d4e5439&quot;/&gt;&lt;mod eID=&quot;c57-0033__main__d4e5425&quot;/&gt; </rdg>
 		</rdgGrp>
 		<rdgGrp n="['this', 'offer;']">
 			<rdg wit="f1818">this offer; </rdg>
@@ -1829,8 +1829,8 @@
 			<rdg wit="fThomas">across Mont Cenis to Leghorn, where </rdg>
 			<rdg wit="f1831">across Mont Cenis to Leghorn, where </rdg>
 		</rdgGrp>
-		<rdgGrp n="['rank', '&lt;delstart/&gt;her father&lt;delend/&gt;']">
-			<rdg wit="fMS">rank &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0033__main__d4e5465&quot;&gt;her father&lt;/del&gt; </rdg>
+		<rdgGrp n="['rank', '', '&lt;delstart/&gt;her father&lt;delend/&gt;']">
+			<rdg wit="fMS">rank &lt;mod sID=&quot;c57-0033__main__d4e5463&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0033__main__d4e5465&quot;&gt;her father&lt;/del&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -1844,31 +1844,13 @@
 	</app>
 	<app>
 		<rdgGrp n="['', 'commander', '', '&lt;delstart/&gt;her&lt;delend/&gt;']">
-			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0033__main__d4e5468&quot;/&gt; commander &lt;lb n=&quot;c57-0033__main__13&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0033__main__d4e5477&quot;&gt;her&lt;/del&gt; </rdg>
+			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0033__main__d4e5468&quot;/&gt;&lt;mod eID=&quot;c57-0033__main__d4e5463&quot;/&gt; commander &lt;lb n=&quot;c57-0033__main__13&quot;/&gt;&lt;mod sID=&quot;c57-0033__main__d4e5475&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0033__main__d4e5477&quot;&gt;her&lt;/del&gt; </rdg>
 		</rdgGrp>
-		<rdgGrp n="['had', 'decided', 'to', 'wait', 'a', 'favourable', 'opportunity', 'of', 'passing', 'into', 'some', 'part', 'of', 'the', 'turkish', 'dominions.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&quot;safie', 'resolved', 'to', 'remain', 'with', 'her', 'father', 'until', 'the', 'moment', 'of', 'his', 'departure,', 'before', 'which', 'time', 'the', 'turk', 'renewed', 'his', 'promise', 'that', 'she', 'should', 'be', 'united', 'to', 'his', 'deliverer;', 'and', 'felix', 'remained', 'with', 'them', 'in', 'expectation', 'of', 'that', 'event;', 'and', 'in', 'the', 'mean', 'time', 'he', 'enjoyed', 'the', 'society', 'of', 'the', 'arabian,', 'who', 'exhibited', 'towards', 'him', 'the', 'simplest', 'and', 'tenderest', 'affection.', 'they', 'conversed', 'with', 'one', 'another', 'through', 'the', 'means', 'of', 'an', 'interpreter,', 'and', 'sometimes', 'with', 'the', 'interpretation', 'of', 'looks;', 'and', 'safie', 'sang', 'to', 'him', 'the', 'divine', 'airs', 'of', 'her', 'native', 'country.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&quot;the', 'turk', 'allowed', 'this', 'intimacy', 'to', 'take', 'place,', 'and', 'encouraged', 'the', 'hopes', 'of', 'the', 'youthful', 'lovers,', 'while', 'in', 'his', 'heart', 'he', 'had', 'formed', 'far', 'other', 'plans.', 'he', 'loathed', 'the', 'idea', 'that', 'his', 'daughter', 'should', 'be', 'united', 'to', 'a', 'christian;', 'but', 'he', 'feared', 'the', 'resentment', 'of']">
-			<rdg wit="f1818">had decided to wait a favourable opportunity of passing into some part of the Turkish dominions. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p10&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p11&quot;/&gt; “Safie resolved to remain with her father until the moment of his depar&lt;pb xml:id=&quot;F1818_v2_095&quot; n=&quot;091&quot;/&gt;ture, before which time the Turk renewed his promise that she should be united to his deliverer; and Felix remained with them in expectation of that event; and in the mean time he enjoyed the society of the Arabian, who exhibited towards him the simplest and tenderest affection. They conversed with one another through the means of an interpreter, and sometimes with the interpretation of looks; and Safie sang to him the divine airs of her native country. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p11&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p12&quot;/&gt; “The Turk allowed this intimacy to take place, and encouraged the hopes of the youthful lovers, while in his heart he had formed far other plans. He loathed the idea that his daughter should be united to a Christian; but he feared the resentment of </rdg>
-			<rdg wit="f1823">had decided to wait a favourable opportunity of passing into some part of the Turkish dominions. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p10&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p11&quot;/&gt; “Safie resolved to remain with her father until the moment of his depar&lt;pb xml:id=&quot;F1823_v2_296&quot; n=&quot;23&quot;/&gt;ture, before which time the Turk renewed his promise that she should be united to his deliverer; and Felix remained with them in expectation of that event; and in the mean time he enjoyed the society of the Arabian, who exhibited towards him the simplest and tenderest affection. They conversed with one another through the means of an interpreter, and sometimes with the interpretation of looks; and Safie sang to him the divine airs of her native country. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p11&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p12&quot;/&gt; “The Turk allowed this intimacy to take place, and encouraged the hopes of the youthful lovers, while in his heart he had formed far other plans. He loathed the idea that his daughter should be united to a Christian; but he feared the resentment of </rdg>
-			<rdg wit="fThomas">had decided to wait a favourable opportunity of passing into some part of the Turkish dominions. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p10&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p11&quot;/&gt; “Safie resolved to remain with her father until the moment of his depar&lt;pb xml:id=&quot;F1818_v2_095&quot; n=&quot;091&quot;/&gt;ture, before which time the Turk renewed his promise that she should be united to his deliverer; and Felix remained with them in expectation of that event; and in the mean time he enjoyed the society of the Arabian, who exhibited towards him the simplest and tenderest affection. They conversed with one another through the means of an interpreter, and sometimes with the interpretation of looks; and Safie sang to him the divine airs of her native country. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p11&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p12&quot;/&gt; “The Turk allowed this intimacy to take place, and encouraged the hopes of the youthful lovers, while in his heart he had formed far other plans. He loathed the idea that his daughter should be united to a Christian; but he feared the resentment of </rdg>
-			<rdg wit="f1831">had decided to wait a favourable opportunity of passing into some part of the Turkish dominions. &lt;p eID=&quot;novel1_letter4_chapter14_div4_div14_p10&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter14_div4_div14_p11&quot;/&gt; “Safie resolved to remain with her father until the moment of his departure, before which time the Turk renewed his promise that she should be united to his deliverer; and Felix remained with them in expectation of that event; and in the mean time he enjoyed the society of the Arabian, who exhibited towards him the simplest and tenderest affection. They conversed with one another through the means of an interpreter, and sometimes with the interpretation of looks; and Safie sang to him the divine airs of her native country. &lt;p eID=&quot;novel1_letter4_chapter14_div4_div14_p11&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter14_div4_div14_p12&quot;/&gt; “The Turk allowed this intimacy to take place, and encouraged the hopes of the youthful lovers, while in his heart he had formed far other plans. He loathed the idea that his daughter should be united to a Christian; but he feared the resentment of </rdg>
-		</rdgGrp>
-	</app>
-	<app>
-		<rdgGrp n="['felix']">
-			<rdg wit="f1818">Felix </rdg>
-			<rdg wit="fThomas">Felix </rdg>
-		</rdgGrp>
-		<rdgGrp n="['felix,']">
-			<rdg wit="f1823">Felix, </rdg>
-			<rdg wit="f1831">Felix, </rdg>
-		</rdgGrp>
-	</app>
-	<app>
-		<rdgGrp n="['if', 'he', 'should', 'appear', 'lukewarm;', 'for', 'he', 'knew', 'that', 'he', 'was', 'still', 'in', 'the', 'power', 'of', 'his', 'deliverer,', 'if', 'he', 'should', 'choose', 'to', 'betray', 'him', 'to', 'the', 'italian', 'state', 'which', 'they', 'inhabited.', 'he', 'revolved', 'a', 'thousand', 'plans', 'by', 'which', 'he', 'should', 'be', 'enabled', 'to', 'prolong', 'the', 'deceit', 'until', 'it', 'might', 'be', 'no', 'longer', 'necessary,', 'and', 'secretly', 'to', 'take']">
-			<rdg wit="f1818">if he should appear lukewarm; for he knew that he was still in the power of his deliverer, if he should choose to betray &lt;pb xml:id=&quot;F1818_v2_096&quot; n=&quot;092&quot;/&gt;him to the Italian state which they inhabited. He revolved a thousand plans by which he should be enabled to prolong the deceit until it might be no longer necessary, and secretly to take </rdg>
-			<rdg wit="f1823">if he should appear lukewarm; for he knew that he was still in the power of his deliverer, if he should choose to betray &lt;pb xml:id=&quot;F1823_v2_297&quot; n=&quot;24&quot;/&gt;him to the Italian state which they inhabited. He revolved a thousand plans by which he should be enabled to prolong the deceit until it might be no longer necessary, and secretly to take </rdg>
-			<rdg wit="fThomas">if he should appear lukewarm; for he knew that he was still in the power of his deliverer, if he should choose to betray &lt;pb xml:id=&quot;F1818_v2_096&quot; n=&quot;092&quot;/&gt;him to the Italian state which they inhabited. He revolved a thousand plans by which he should be enabled to prolong the deceit until it might be no longer necessary, and secretly to take </rdg>
-			<rdg wit="f1831">if he should appear lukewarm; for he knew that he was still in the power of his deliverer, if he should choose to betray him to the Italian state which they inhabited. He revolved a thousand plans by which he should be enabled to prolong the deceit until it might be no longer necessary, and secretly to take </rdg>
+		<rdgGrp n="['had', 'decided', 'to', 'wait', 'a', 'favourable', 'opportunity', 'of', 'passing', 'into', 'some', 'part', 'of', 'the', 'turkish', 'dominions.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&quot;safie', 'resolved', 'to', 'remain', 'with', 'her', 'father', 'until', 'the', 'moment', 'of', 'his', 'departure,', 'before', 'which', 'time', 'the', 'turk', 'renewed', 'his', 'promise', 'that', 'she', 'should', 'be', 'united', 'to', 'his', 'deliverer;', 'and', 'felix', 'remained', 'with', 'them', 'in', 'expectation', 'of', 'that', 'event;', 'and', 'in', 'the', 'mean', 'time', 'he', 'enjoyed', 'the', 'society', 'of', 'the', 'arabian,', 'who', 'exhibited', 'towards', 'him', 'the', 'simplest', 'and', 'tenderest', 'affection.', 'they', 'conversed', 'with', 'one', 'another', 'through', 'the', 'means', 'of', 'an', 'interpreter,', 'and', 'sometimes', 'with', 'the', 'interpretation', 'of', 'looks;', 'and', 'safie', 'sang', 'to', 'him', 'the', 'divine', 'airs', 'of', 'her', 'native', 'country.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&quot;the', 'turk', 'allowed', 'this', 'intimacy', 'to', 'take', 'place,', 'and', 'encouraged', 'the', 'hopes', 'of', 'the', 'youthful', 'lovers,', 'while', 'in', 'his', 'heart', 'he', 'had', 'formed', 'far', 'other', 'plans.', 'he', 'loathed', 'the', 'idea', 'that']">
+			<rdg wit="f1818">had decided to wait a favourable opportunity of passing into some part of the Turkish dominions. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p10&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p11&quot;/&gt; “Safie resolved to remain with her father until the moment of his depar&lt;pb xml:id=&quot;F1818_v2_095&quot; n=&quot;091&quot;/&gt;ture, before which time the Turk renewed his promise that she should be united to his deliverer; and Felix remained with them in expectation of that event; and in the mean time he enjoyed the society of the Arabian, who exhibited towards him the simplest and tenderest affection. They conversed with one another through the means of an interpreter, and sometimes with the interpretation of looks; and Safie sang to him the divine airs of her native country. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p11&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p12&quot;/&gt; “The Turk allowed this intimacy to take place, and encouraged the hopes of the youthful lovers, while in his heart he had formed far other plans. He loathed the idea that </rdg>
+			<rdg wit="f1823">had decided to wait a favourable opportunity of passing into some part of the Turkish dominions. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p10&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p11&quot;/&gt; “Safie resolved to remain with her father until the moment of his depar&lt;pb xml:id=&quot;F1823_v2_296&quot; n=&quot;23&quot;/&gt;ture, before which time the Turk renewed his promise that she should be united to his deliverer; and Felix remained with them in expectation of that event; and in the mean time he enjoyed the society of the Arabian, who exhibited towards him the simplest and tenderest affection. They conversed with one another through the means of an interpreter, and sometimes with the interpretation of looks; and Safie sang to him the divine airs of her native country. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p11&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p12&quot;/&gt; “The Turk allowed this intimacy to take place, and encouraged the hopes of the youthful lovers, while in his heart he had formed far other plans. He loathed the idea that </rdg>
+			<rdg wit="fThomas">had decided to wait a favourable opportunity of passing into some part of the Turkish dominions. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p10&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p11&quot;/&gt; “Safie resolved to remain with her father until the moment of his depar&lt;pb xml:id=&quot;F1818_v2_095&quot; n=&quot;091&quot;/&gt;ture, before which time the Turk renewed his promise that she should be united to his deliverer; and Felix remained with them in expectation of that event; and in the mean time he enjoyed the society of the Arabian, who exhibited towards him the simplest and tenderest affection. They conversed with one another through the means of an interpreter, and sometimes with the interpretation of looks; and Safie sang to him the divine airs of her native country. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p11&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p12&quot;/&gt; “The Turk allowed this intimacy to take place, and encouraged the hopes of the youthful lovers, while in his heart he had formed far other plans. He loathed the idea that </rdg>
+			<rdg wit="f1831">had decided to wait a favourable opportunity of passing into some part of the Turkish dominions. &lt;p eID=&quot;novel1_letter4_chapter14_div4_div14_p10&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter14_div4_div14_p11&quot;/&gt; “Safie resolved to remain with her father until the moment of his departure, before which time the Turk renewed his promise that she should be united to his deliverer; and Felix remained with them in expectation of that event; and in the mean time he enjoyed the society of the Arabian, who exhibited towards him the simplest and tenderest affection. They conversed with one another through the means of an interpreter, and sometimes with the interpretation of looks; and Safie sang to him the divine airs of her native country. &lt;p eID=&quot;novel1_letter4_chapter14_div4_div14_p11&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter14_div4_div14_p12&quot;/&gt; “The Turk allowed this intimacy to take place, and encouraged the hopes of the youthful lovers, while in his heart he had formed far other plans. He loathed the idea that </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -1882,13 +1864,51 @@
 	</app>
 	<app>
 		<rdgGrp n="['']">
-			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0033__main__d4e5480&quot;/&gt; </rdg>
+			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0033__main__d4e5480&quot;/&gt;&lt;mod eID=&quot;c57-0033__main__d4e5475&quot;/&gt; </rdg>
 		</rdgGrp>
-		<rdgGrp n="['with', 'him', 'when', 'he', 'departed.', 'his', 'plans', 'were']">
-			<rdg wit="f1818">with him when he departed. His plans were </rdg>
-			<rdg wit="f1823">with him when he departed. His plans were </rdg>
-			<rdg wit="fThomas">with him when he departed. His plans were </rdg>
-			<rdg wit="f1831">with him when he departed. His plans were </rdg>
+		<rdgGrp n="['should', 'be', 'united', 'to', 'a', 'christian;', 'but', 'he', 'feared', 'the', 'resentment', 'of']">
+			<rdg wit="f1818">should be united to a Christian; but he feared the resentment of </rdg>
+			<rdg wit="f1823">should be united to a Christian; but he feared the resentment of </rdg>
+			<rdg wit="fThomas">should be united to a Christian; but he feared the resentment of </rdg>
+			<rdg wit="f1831">should be united to a Christian; but he feared the resentment of </rdg>
+		</rdgGrp>
+	</app>
+	<app>
+		<rdgGrp n="['felix']">
+			<rdg wit="f1818">Felix </rdg>
+			<rdg wit="fThomas">Felix </rdg>
+		</rdgGrp>
+		<rdgGrp n="['felix,']">
+			<rdg wit="f1823">Felix, </rdg>
+			<rdg wit="f1831">Felix, </rdg>
+		</rdgGrp>
+	</app>
+	<app>
+		<rdgGrp n="['if', 'he', 'should', 'appear', 'lukewarm;', 'for', 'he', 'knew', 'that', 'he', 'was', 'still', 'in', 'the', 'power', 'of', 'his', 'deliverer,', 'if', 'he', 'should', 'choose', 'to', 'betray', 'him', 'to', 'the', 'italian', 'state', 'which', 'they', 'inhabited.', 'he', 'revolved', 'a', 'thousand', 'plans', 'by', 'which', 'he', 'should', 'be', 'enabled', 'to', 'prolong', 'the', 'deceit', 'until', 'it', 'might', 'be', 'no', 'longer', 'necessary,', 'and', 'secretly']">
+			<rdg wit="f1818">if he should appear lukewarm; for he knew that he was still in the power of his deliverer, if he should choose to betray &lt;pb xml:id=&quot;F1818_v2_096&quot; n=&quot;092&quot;/&gt;him to the Italian state which they inhabited. He revolved a thousand plans by which he should be enabled to prolong the deceit until it might be no longer necessary, and secretly </rdg>
+			<rdg wit="f1823">if he should appear lukewarm; for he knew that he was still in the power of his deliverer, if he should choose to betray &lt;pb xml:id=&quot;F1823_v2_297&quot; n=&quot;24&quot;/&gt;him to the Italian state which they inhabited. He revolved a thousand plans by which he should be enabled to prolong the deceit until it might be no longer necessary, and secretly </rdg>
+			<rdg wit="fThomas">if he should appear lukewarm; for he knew that he was still in the power of his deliverer, if he should choose to betray &lt;pb xml:id=&quot;F1818_v2_096&quot; n=&quot;092&quot;/&gt;him to the Italian state which they inhabited. He revolved a thousand plans by which he should be enabled to prolong the deceit until it might be no longer necessary, and secretly </rdg>
+			<rdg wit="f1831">if he should appear lukewarm; for he knew that he was still in the power of his deliverer, if he should choose to betray him to the Italian state which they inhabited. He revolved a thousand plans by which he should be enabled to prolong the deceit until it might be no longer necessary, and secretly </rdg>
+		</rdgGrp>
+	</app>
+	<app>
+		<rdgGrp n="['to']">
+			<rdg wit="f1818">to </rdg>
+			<rdg wit="f1823">to </rdg>
+			<rdg wit="fThomas">to </rdg>
+			<rdg wit="f1831">to </rdg>
+			<rdg wit="fMS">to </rdg>
+		</rdgGrp>
+	</app>
+	<app>
+		<rdgGrp n="['take', 'his', 'daughter', 'with', 'him', 'when', 'he', 'departed.', 'his', 'plans', 'were']">
+			<rdg wit="f1818">take his daughter with him when he departed. His plans were </rdg>
+			<rdg wit="f1823">take his daughter with him when he departed. His plans were </rdg>
+			<rdg wit="fThomas">take his daughter with him when he departed. His plans were </rdg>
+			<rdg wit="f1831">take his daughter with him when he departed. His plans were </rdg>
+		</rdgGrp>
+		<rdgGrp n="['think']">
+			<rdg wit="fMS">think </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -1899,11 +1919,28 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['facilitated', 'by', 'the', 'news', 'which', 'arrived', 'from', 'paris.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&quot;the', 'government', 'of', 'france', 'were', 'greatly', 'enraged', 'at', 'the', 'escape', 'of', 'their', 'victim,', 'and', 'spared', 'no', 'pains', 'to', 'detect', 'and', 'punish', 'his', 'deliverer.', 'the', 'plot', 'of', 'felix', 'was', 'quickly', 'discovered,', 'and', 'de', 'lacey', 'and', 'agatha', 'were', 'thrown', 'into', 'prison.', 'the', 'news', 'reached', 'felix,', 'and', 'roused', 'him', 'from', 'his', 'dream', 'of', 'pleasure.', 'his', 'blind', 'and', 'aged', 'father,', 'and', 'his', 'gentle', 'sister,', 'lay', 'in', 'a', 'noisome', 'dungeon,', 'while', 'he', 'enjoyed', 'the', 'free', 'air,', 'and', 'the', 'society', 'of', 'her', 'whom', 'he', 'loved.', 'this', 'idea', 'was', 'torture', 'to', 'him.', 'he', 'quickly', 'arranged', 'with', 'the']">
-			<rdg wit="f1818">facilitated by the news which arrived from Paris. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p12&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p13&quot;/&gt; “The government of France were greatly enraged at the escape of their victim, and spared no pains to detect and punish his deliverer. The plot of Felix was quickly discovered, and De Lacey and Agatha were thrown into prison. The news reached Felix, and roused him from his dream of pleasure. His blind and aged father, and his gentle sister, lay in a noisome dungeon, while he enjoyed the free air, and the society of her whom he loved. This idea was torture to him. He quickly arranged with the </rdg>
-			<rdg wit="f1823">facilitated by the news which arrived from Paris. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p12&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p13&quot;/&gt; “The government of France were greatly enraged at the escape of their victim, and spared no pains to detect and punish his deliverer. The plot of Felix was quickly discovered, and De Lacey and Agatha were thrown into prison. The news reached Felix, and roused him from his dream of pleasure. His blind and aged father, and his gentle sister, lay in a noisome dungeon, while he enjoyed the free air, and the society of her whom he loved. This idea was torture to him. He quickly arranged with the </rdg>
-			<rdg wit="fThomas">facilitated by the news which arrived from Paris. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p12&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p13&quot;/&gt; “The government of France were greatly enraged at the escape of their victim, and spared no pains to detect and punish his deliverer. The plot of Felix was quickly discovered, and De Lacey and Agatha were thrown into prison. The news reached Felix, and roused him from his dream of pleasure. His blind and aged father, and his gentle sister, lay in a noisome dungeon, while he enjoyed the free air, and the society of her whom he loved. This idea was torture to him. He quickly arranged with the </rdg>
-			<rdg wit="f1831">facilitated by the news which arrived from Paris. &lt;p eID=&quot;novel1_letter4_chapter14_div4_div14_p12&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter14_div4_div14_p13&quot;/&gt; “The government of France were greatly enraged at the escape of their victim, and spared no pains to detect and punish his deliverer. The plot of Felix was quickly discovered, and De Lacey and Agatha were thrown into prison. The news reached Felix, and roused him from his dream of pleasure. His blind and aged father, and his gentle sister, lay in a noisome dungeon, while he enjoyed the free air, and the society of her whom he loved. This idea was &lt;pb xml:id=&quot;F1831_v_124&quot; n=&quot;108&quot;/&gt;torture to him. He quickly arranged with the </rdg>
+		<rdgGrp n="['facilitated', 'by', 'the', 'news', 'which', 'arrived', 'from', 'paris.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&quot;the', 'government', 'of', 'france', 'were', 'greatly', 'enraged', 'at', 'the', 'escape', 'of', 'their', 'victim,', 'and', 'spared']">
+			<rdg wit="f1818">facilitated by the news which arrived from Paris. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p12&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p13&quot;/&gt; “The government of France were greatly enraged at the escape of their victim, and spared </rdg>
+			<rdg wit="f1823">facilitated by the news which arrived from Paris. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p12&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p13&quot;/&gt; “The government of France were greatly enraged at the escape of their victim, and spared </rdg>
+			<rdg wit="fThomas">facilitated by the news which arrived from Paris. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p12&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p13&quot;/&gt; “The government of France were greatly enraged at the escape of their victim, and spared </rdg>
+			<rdg wit="f1831">facilitated by the news which arrived from Paris. &lt;p eID=&quot;novel1_letter4_chapter14_div4_div14_p12&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter14_div4_div14_p13&quot;/&gt; “The government of France were greatly enraged at the escape of their victim, and spared </rdg>
+		</rdgGrp>
+	</app>
+	<app>
+		<rdgGrp n="['no']">
+			<rdg wit="f1818">no </rdg>
+			<rdg wit="f1823">no </rdg>
+			<rdg wit="fThomas">no </rdg>
+			<rdg wit="f1831">no </rdg>
+			<rdg wit="fMS">no </rdg>
+		</rdgGrp>
+	</app>
+	<app>
+		<rdgGrp n="['pains', 'to', 'detect', 'and', 'punish', 'his', 'deliverer.', 'the', 'plot', 'of', 'felix', 'was', 'quickly', 'discovered,', 'and', 'de', 'lacey', 'and', 'agatha', 'were', 'thrown', 'into', 'prison.', 'the', 'news', 'reached', 'felix,', 'and', 'roused', 'him', 'from', 'his', 'dream', 'of', 'pleasure.', 'his', 'blind', 'and', 'aged', 'father,', 'and', 'his', 'gentle', 'sister,', 'lay', 'in', 'a', 'noisome', 'dungeon,', 'while', 'he', 'enjoyed', 'the', 'free', 'air,', 'and', 'the', 'society', 'of', 'her', 'whom', 'he', 'loved.', 'this', 'idea', 'was', 'torture', 'to', 'him.', 'he', 'quickly', 'arranged', 'with', 'the']">
+			<rdg wit="f1818">pains to detect and punish his deliverer. The plot of Felix was quickly discovered, and De Lacey and Agatha were thrown into prison. The news reached Felix, and roused him from his dream of pleasure. His blind and aged father, and his gentle sister, lay in a noisome dungeon, while he enjoyed the free air, and the society of her whom he loved. This idea was torture to him. He quickly arranged with the </rdg>
+			<rdg wit="f1823">pains to detect and punish his deliverer. The plot of Felix was quickly discovered, and De Lacey and Agatha were thrown into prison. The news reached Felix, and roused him from his dream of pleasure. His blind and aged father, and his gentle sister, lay in a noisome dungeon, while he enjoyed the free air, and the society of her whom he loved. This idea was torture to him. He quickly arranged with the </rdg>
+			<rdg wit="fThomas">pains to detect and punish his deliverer. The plot of Felix was quickly discovered, and De Lacey and Agatha were thrown into prison. The news reached Felix, and roused him from his dream of pleasure. His blind and aged father, and his gentle sister, lay in a noisome dungeon, while he enjoyed the free air, and the society of her whom he loved. This idea was torture to him. He quickly arranged with the </rdg>
+			<rdg wit="f1831">pains to detect and punish his deliverer. The plot of Felix was quickly discovered, and De Lacey and Agatha were thrown into prison. The news reached Felix, and roused him from his dream of pleasure. His blind and aged father, and his gentle sister, lay in a noisome dungeon, while he enjoyed the free air, and the society of her whom he loved. This idea was &lt;pb xml:id=&quot;F1831_v_124&quot; n=&quot;108&quot;/&gt;torture to him. He quickly arranged with the </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -2021,25 +2058,48 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['gloried', 'in', 'it:', 'but', 'the', 'ingratitude', 'of', 'the', 'turk,', 'and', 'the', 'loss', 'of', 'his', 'beloved', 'safie,', 'were', 'misfortunes', 'more', 'bitter', 'and', 'irreparable.', 'the', 'arrival', 'of', 'the', 'arabian', 'now', 'infused', 'new', 'life', 'into', 'his', 'soul.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&quot;when', 'the', 'news', 'reached', 'leghorn,', 'that', 'felix', 'was', 'deprived', 'of', 'his', 'wealth', 'and', 'rank,', 'the', 'merchant', 'commanded', 'his', 'daughter']">
-			<rdg wit="f1818">gloried in it: but the ingratitude of the Turk, and the loss of his beloved Safie, were misfortunes more bitter and irreparable. The arrival of the Arabian now infused new life into his soul. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p16&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p17&quot;/&gt; “When the news reached Leghorn, that Felix was deprived of his wealth and rank, the merchant commanded his daughter </rdg>
-			<rdg wit="f1823">gloried in it: but the ingratitude of the Turk, and the loss of his beloved Safie, were misfortunes more bitter and irreparable. The arrival of the Arabian now infused new life into his soul. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p16&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p17&quot;/&gt; “When the news reached Leghorn, that Felix was deprived of his wealth and rank, the merchant commanded his daughter </rdg>
-			<rdg wit="fThomas">gloried in it: but the ingratitude of the Turk, and the loss of his beloved Safie, were misfortunes more bitter and irreparable. The arrival of the Arabian now infused new life into his soul. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p15&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p16&quot;/&gt; “When the news reached Leghorn, that Felix was deprived of his wealth and rank, the merchant commanded his daughter </rdg>
-			<rdg wit="f1831">gloried in it: but the ingratitude of the Turk, and the loss of his beloved Safie, were misfortunes more bitter and irreparable. The arrival of the Arabian now infused new life into his soul. &lt;p eID=&quot;novel1_letter4_chapter14_div4_div14_p16&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter14_div4_div14_p17&quot;/&gt; “When the news reached Leghorn, that Felix was deprived of his wealth and rank, the merchant commanded his daughter </rdg>
+		<rdgGrp n="['gloried', 'in', 'it:', 'but', 'the', 'ingratitude', 'of', 'the', 'turk,', 'and', 'the', 'loss', 'of', 'his', 'beloved', 'safie,', 'were', 'misfortunes']">
+			<rdg wit="f1818">gloried in it: but the ingratitude of the Turk, and the loss of his beloved Safie, were misfortunes </rdg>
+			<rdg wit="f1823">gloried in it: but the ingratitude of the Turk, and the loss of his beloved Safie, were misfortunes </rdg>
+			<rdg wit="fThomas">gloried in it: but the ingratitude of the Turk, and the loss of his beloved Safie, were misfortunes </rdg>
+			<rdg wit="f1831">gloried in it: but the ingratitude of the Turk, and the loss of his beloved Safie, were misfortunes </rdg>
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['to', 'think', 'no', 'more', 'of']">
-			<rdg wit="f1818">to think no more of </rdg>
-			<rdg wit="f1823">to think no more of </rdg>
-			<rdg wit="fThomas">to think no more of </rdg>
-			<rdg wit="f1831">to think no more of </rdg>
-			<rdg wit="fMS">to think no more of </rdg>
+		<rdgGrp n="['more']">
+			<rdg wit="f1818">more </rdg>
+			<rdg wit="f1823">more </rdg>
+			<rdg wit="fThomas">more </rdg>
+			<rdg wit="f1831">more </rdg>
+			<rdg wit="fMS">more </rdg>
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['&lt;delstart/&gt;him&lt;delend/&gt;']">
-			<rdg wit="fMS">&lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0033__main__d4e5486&quot;&gt;him&lt;/del&gt; </rdg>
+		<rdgGrp n="['bitter', 'and', 'irreparable.', 'the', 'arrival', 'of', 'the', 'arabian', 'now', 'infused', 'new', 'life', 'into', 'his', 'soul.', '&lt;p-end/&gt;', '&lt;p-start/&gt;', '&quot;when', 'the', 'news', 'reached', 'leghorn,', 'that', 'felix', 'was', 'deprived']">
+			<rdg wit="f1818">bitter and irreparable. The arrival of the Arabian now infused new life into his soul. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p16&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p17&quot;/&gt; “When the news reached Leghorn, that Felix was deprived </rdg>
+			<rdg wit="f1823">bitter and irreparable. The arrival of the Arabian now infused new life into his soul. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p16&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p17&quot;/&gt; “When the news reached Leghorn, that Felix was deprived </rdg>
+			<rdg wit="fThomas">bitter and irreparable. The arrival of the Arabian now infused new life into his soul. &lt;p eID=&quot;novel1_letter4_chapter13_div4_div14_p15&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter13_div4_div14_p16&quot;/&gt; “When the news reached Leghorn, that Felix was deprived </rdg>
+			<rdg wit="f1831">bitter and irreparable. The arrival of the Arabian now infused new life into his soul. &lt;p eID=&quot;novel1_letter4_chapter14_div4_div14_p16&quot;/&gt; &lt;p sID=&quot;novel1_letter4_chapter14_div4_div14_p17&quot;/&gt; “When the news reached Leghorn, that Felix was deprived </rdg>
+		</rdgGrp>
+	</app>
+	<app>
+		<rdgGrp n="['of']">
+			<rdg wit="f1818">of </rdg>
+			<rdg wit="f1823">of </rdg>
+			<rdg wit="fThomas">of </rdg>
+			<rdg wit="f1831">of </rdg>
+			<rdg wit="fMS">of </rdg>
+		</rdgGrp>
+	</app>
+	<app>
+		<rdgGrp n="['', '&lt;delstart/&gt;him&lt;delend/&gt;']">
+			<rdg wit="fMS">&lt;mod sID=&quot;c57-0033__main__d4e5484&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0033__main__d4e5486&quot;&gt;him&lt;/del&gt; </rdg>
+		</rdgGrp>
+		<rdgGrp n="['his', 'wealth', 'and', 'rank,', 'the', 'merchant', 'commanded', 'his', 'daughter', 'to', 'think', 'no', 'more', 'of']">
+			<rdg wit="f1818">his wealth and rank, the merchant commanded his daughter to think no more of </rdg>
+			<rdg wit="f1823">his wealth and rank, the merchant commanded his daughter to think no more of </rdg>
+			<rdg wit="fThomas">his wealth and rank, the merchant commanded his daughter to think no more of </rdg>
+			<rdg wit="f1831">his wealth and rank, the merchant commanded his daughter to think no more of </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -2053,7 +2113,7 @@
 	</app>
 	<app>
 		<rdgGrp n="['lover', '']">
-			<rdg wit="fMS">lover &lt;sga-add eID=&quot;c57-0033__main__d4e5489&quot;/&gt; </rdg>
+			<rdg wit="fMS">lover &lt;sga-add eID=&quot;c57-0033__main__d4e5489&quot;/&gt;&lt;mod eID=&quot;c57-0033__main__d4e5484&quot;/&gt; </rdg>
 		</rdgGrp>
 		<rdgGrp n="['lover,']">
 			<rdg wit="f1818">&lt;pb xml:id=&quot;F1818_v2_099&quot; n=&quot;095&quot;/&gt;lover, </rdg>
@@ -2343,8 +2403,8 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['&lt;delstart/&gt;would&lt;delend/&gt;', '', '&lt;delstart/&gt;was&lt;delend/&gt;']">
-			<rdg wit="fMS">&lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0033__main__d4e5538&quot;&gt;would&lt;/del&gt; &lt;sga-add place=&quot;superlinear&quot; sID=&quot;c57-0033__main__d4e5541&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0033__main__d4e5543&quot;&gt;was&lt;/del&gt; </rdg>
+		<rdgGrp n="['', '&lt;delstart/&gt;would&lt;delend/&gt;', '', '&lt;delstart/&gt;was&lt;delend/&gt;']">
+			<rdg wit="fMS">&lt;mod sID=&quot;c57-0033__main__d4e5536&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0033__main__d4e5538&quot;&gt;would&lt;/del&gt; &lt;sga-add place=&quot;superlinear&quot; sID=&quot;c57-0033__main__d4e5541&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0033__main__d4e5543&quot;&gt;was&lt;/del&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -2357,8 +2417,8 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['', '']">
-			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0033__main__d4e5541&quot;/&gt; &lt;mdel&gt;b&lt;/mdel&gt; </rdg>
+		<rdgGrp n="['', '&lt;mdel&gt;b&lt;/mdel&gt;', '']">
+			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0033__main__d4e5541&quot;/&gt; &lt;mdel&gt;b&lt;/mdel&gt; &lt;mod eID=&quot;c57-0033__main__d4e5536&quot;/&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -2372,7 +2432,7 @@
 	</app>
 	<app>
 		<rdgGrp n="['', '']">
-			<rdg wit="fMS">&lt;sga-add place=&quot;sublinear&quot; sID=&quot;c57-0033__main__d4e5554&quot;/&gt; &lt;metamark function=&quot;insert&quot;&gt;^&lt;/metamark&gt; </rdg>
+			<rdg wit="fMS">&lt;mod sID=&quot;c57-0033__main__d4e5552&quot;/&gt;&lt;sga-add place=&quot;sublinear&quot; sID=&quot;c57-0033__main__d4e5554&quot;/&gt; &lt;metamark function=&quot;insert&quot;&gt;^&lt;/metamark&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -2385,8 +2445,8 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['', 'to the french government–', 'he', 'had', 'just', 'heard', 'of', 'a', 'small', 'vessel', 'bound', 'for', 'constantinople', 'which', 'he', 'had', 'consequently', 'hired', 'a', 'vessel', 'to', 'convey', 'him', 'to', '&lt;delstart/&gt;can&lt;delend/&gt;', 'constantinople', '']">
-			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0033__main__d4e5560&quot;/&gt; &lt;longToken&gt;to the French Government–&lt;/longToken&gt; &lt;lb n=&quot;c57-0033__main__26&quot;/&gt;&lt;delSpan rend=&quot;strikethrough&quot; spanTo=&quot;#c57-0033.04&quot;/&gt;He had just heard of a small vessel &lt;lb n=&quot;c57-0033__main__27&quot;/&gt;bound for Constantinople which &lt;anchor xml:id=&quot;c57-0033.04&quot;/&gt;He had &lt;lb n=&quot;c57-0033__main__28&quot;/&gt;consequently hired a vessel to convey him &lt;lb n=&quot;c57-0034__main__1&quot;/&gt;to &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0034__main__d4e5585&quot;&gt;Can&lt;/del&gt; Constantinople &lt;mdel&gt;in&lt;/mdel&gt; </rdg>
+		<rdgGrp n="['', 'to the french government–', 'he', 'had', 'just', 'heard', 'of', 'a', 'small', 'vessel', 'bound', 'for', 'constantinople', 'which', 'he', 'had', 'consequently', 'hired', 'a', 'vessel', 'to', 'convey', 'him', 'to', '&lt;delstart/&gt;can&lt;delend/&gt;', 'constantinople', '', '&lt;mdel&gt;in&lt;/mdel&gt;']">
+			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0033__main__d4e5560&quot;/&gt;&lt;mod eID=&quot;c57-0033__main__d4e5552&quot;/&gt; &lt;longToken&gt;to the French Government–&lt;/longToken&gt; &lt;lb n=&quot;c57-0033__main__26&quot;/&gt;&lt;delSpan rend=&quot;strikethrough&quot; spanTo=&quot;#c57-0033.04&quot;/&gt;He had just heard of a small vessel &lt;lb n=&quot;c57-0033__main__27&quot;/&gt;bound for Constantinople which &lt;anchor xml:id=&quot;c57-0033.04&quot;/&gt;He had &lt;lb n=&quot;c57-0033__main__28&quot;/&gt;consequently hired a vessel to convey him &lt;lb n=&quot;c57-0034__main__1&quot;/&gt;to &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0034__main__d4e5585&quot;&gt;Can&lt;/del&gt; Constantinople &lt;mod sID=&quot;c57-0034__main__d4e5588&quot;/&gt; &lt;mdel&gt;in&lt;/mdel&gt; </rdg>
 		</rdgGrp>
 		<rdgGrp n="['to the french government; ']">
 			<rdg wit="f1818">&lt;longToken&gt;to the French government; &lt;/longToken&gt; </rdg>
@@ -2416,7 +2476,7 @@
 	</app>
 	<app>
 		<rdgGrp n="['']">
-			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0034__main__d4e5592&quot;/&gt; </rdg>
+			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0034__main__d4e5592&quot;/&gt;&lt;mod eID=&quot;c57-0034__main__d4e5588&quot;/&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -2925,8 +2985,8 @@
 		</rdgGrp>
 	</app>
 	<app>
-		<rdgGrp n="['', '20', '']">
-			<rdg wit="fMS">&lt;mdel&gt;50&lt;/mdel&gt; &lt;sga-add place=&quot;superlinear&quot; sID=&quot;c57-0034__main__d4e5710&quot;/&gt;20 &lt;sga-add eID=&quot;c57-0034__main__d4e5710&quot;/&gt; </rdg>
+		<rdgGrp n="['', '&lt;mdel&gt;50&lt;/mdel&gt;', '20', '']">
+			<rdg wit="fMS">&lt;mod sID=&quot;c57-0034__main__d4e5706&quot;/&gt; &lt;mdel&gt;50&lt;/mdel&gt; &lt;sga-add place=&quot;superlinear&quot; sID=&quot;c57-0034__main__d4e5710&quot;/&gt;20 &lt;sga-add eID=&quot;c57-0034__main__d4e5710&quot;/&gt;&lt;mod eID=&quot;c57-0034__main__d4e5706&quot;/&gt; </rdg>
 		</rdgGrp>
 		<rdgGrp n="['twenty']">
 			<rdg wit="f1818">twenty </rdg>
@@ -2980,7 +3040,7 @@
 	</app>
 	<app>
 		<rdgGrp n="['', '']">
-			<rdg wit="fMS">&lt;sga-add place=&quot;sublinear&quot; sID=&quot;c57-0034__main__d4e5720&quot;/&gt; &lt;metamark function=&quot;insert&quot;&gt;^&lt;/metamark&gt; </rdg>
+			<rdg wit="fMS">&lt;mod sID=&quot;c57-0034__main__d4e5718&quot;/&gt;&lt;sga-add place=&quot;sublinear&quot; sID=&quot;c57-0034__main__d4e5720&quot;/&gt; &lt;metamark function=&quot;insert&quot;&gt;^&lt;/metamark&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -2994,7 +3054,7 @@
 	</app>
 	<app>
 		<rdgGrp n="['', 'ill', '&lt;delstart/&gt;and she was retarded wh&lt;delend/&gt;']">
-			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0034__main__d4e5726&quot;/&gt; ill &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0034__main__d4e5730&quot;&gt;and she was retarded wh&lt;/del&gt; </rdg>
+			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0034__main__d4e5726&quot;/&gt;&lt;mod eID=&quot;c57-0034__main__d4e5718&quot;/&gt; ill &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0034__main__d4e5730&quot;&gt;and she was retarded wh&lt;/del&gt; </rdg>
 		</rdgGrp>
 		<rdgGrp n="['ill.']">
 			<rdg wit="f1818">ill. </rdg>
@@ -3063,7 +3123,7 @@
 			<rdg wit="f1823">and </rdg>
 			<rdg wit="fThomas">and </rdg>
 			<rdg wit="f1831">and </rdg>
-			<rdg wit="fMS">&amp; </rdg>
+			<rdg wit="fMS">&amp;&lt;mod sID=&quot;c57-0034__main__d4e5741&quot;/&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -3077,7 +3137,7 @@
 			<rdg wit="f1823">the Arabian was &lt;pb xml:id=&quot;F1823_v2_302&quot; n=&quot;29&quot;/&gt;left </rdg>
 			<rdg wit="fThomas">the Arabian was left </rdg>
 			<rdg wit="f1831">the Arabian was left </rdg>
-			<rdg wit="fMS">&lt;sga-add place=&quot;superlinear&quot; sID=&quot;c57-0034__main__d4e5746&quot;/&gt;the Arabian &lt;sga-add eID=&quot;c57-0034__main__d4e5746&quot;/&gt;&lt;lb n=&quot;c57-0034__main__28&quot;/&gt;was left </rdg>
+			<rdg wit="fMS">&lt;sga-add place=&quot;superlinear&quot; sID=&quot;c57-0034__main__d4e5746&quot;/&gt;the Arabian &lt;sga-add eID=&quot;c57-0034__main__d4e5746&quot;/&gt;&lt;mod eID=&quot;c57-0034__main__d4e5741&quot;/&gt;&lt;lb n=&quot;c57-0034__main__28&quot;/&gt;was left </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -3182,7 +3242,7 @@
 	</app>
 	<app>
 		<rdgGrp n="['', '&lt;delstart/&gt;before her death&lt;delend/&gt;']">
-			<rdg wit="fMS">&lt;lb n=&quot;c57-0035__main__5&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0035__main__d4e5796&quot;&gt;before her death&lt;/del&gt; </rdg>
+			<rdg wit="fMS">&lt;lb n=&quot;c57-0035__main__5&quot;/&gt;&lt;mod sID=&quot;c57-0035__main__d4e5794&quot;/&gt; &lt;del rend=&quot;strikethrough&quot; xml:id=&quot;c57-0035__main__d4e5796&quot;&gt;before her death&lt;/del&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -3196,7 +3256,7 @@
 	</app>
 	<app>
 		<rdgGrp n="['']">
-			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0035__main__d4e5799&quot;/&gt; </rdg>
+			<rdg wit="fMS">&lt;sga-add eID=&quot;c57-0035__main__d4e5799&quot;/&gt;&lt;mod eID=&quot;c57-0035__main__d4e5794&quot;/&gt; </rdg>
 		</rdgGrp>
 	</app>
 	<app>
@@ -3289,4 +3349,4 @@
 		</rdgGrp>
 	</app>
 </cx:apparatus>
-<!-- 2023-03-16 04:51:56.660910 -->
+<!-- 2023-03-16 18:54:06.132637 -->

--- a/python-collation/collate.py
+++ b/python-collation/collate.py
@@ -106,12 +106,12 @@ RE_DOTDASH = re.compile(r'\.–')
 # 2017-05-30 ebb: collated but the tags are not). Decision to make the comments into self-closing elements with text
 # 2017-05-30 ebb: contents as attribute values, and content such as tags simplified to be legal attribute values.
 # 2017-05-22 ebb: I've set anchor elements with @xml:ids to be the indicators of collation "chunks" to process together
-ignore = ['mod', 'sourceDoc', 'xml', 'comment', 'include', 'addSpan', 'handShift', 'damage',
+ignore = ['sourceDoc', 'xml', 'comment', 'include', 'addSpan', 'handShift', 'damage',
           'restore', 'zone', 'surface', 'graphic', 'unclear', 'retrace']
 blockEmpty = ['p', 'div', 'milestone', 'lg', 'l', 'cit', 'quote', 'bibl']
-inlineEmpty = ['pb', 'sga-add', 'delSpan', 'anchor', 'lb', 'gap', 'hi', 'w', 'ab']
-inlineContent = ['del-INNER', 'add-INNER', 'metamark', 'mdel', 'shi']
-inlineVariationEvent = ['head', 'del', 'add', 'note', 'longToken']
+inlineEmpty = ['mod', 'pb', 'sga-add', 'delSpan', 'anchor', 'lb', 'gap', 'hi', 'w', 'ab']
+inlineContent = ['del-INNER', 'add-INNER', 'metamark', 'shi']
+inlineVariationEvent = ['head', 'del', 'mdel', 'add', 'note', 'longToken']
 
 
 # 10-23-2017 ebb rv:
@@ -200,8 +200,8 @@ def normalize(inputText):
     # The lower() at the end lowercases all the normalized strings to simplify the comparison.
 
     normalized = RE_METAMARK.sub('', inputText)
-    #  normalized = RE_MOD.sub('', normalized)
-    # <mod> is in the ignore list like anchor, etc, so why are we presuming it's being read?
+    normalized = RE_MOD.sub('', normalized)
+    # 2023-03-16 How about we actually read it this time? <mod> is in the ignore list like anchor, etc, so why are we presuming it's being read?
     normalized = RE_GAP.sub('', normalized)
     normalized = RE_CLOSEQT.sub('"', normalized)
     normalized = RE_OPENQT.sub('"', normalized)
@@ -252,7 +252,8 @@ def normalize(inputText):
     # Example: <shi rend="underline">should be</shi>
     # Previously, we were eliminating these passages entirely from the normalization, which was a serious error!
     # We have not been considering highlighting or emphasis <hi> or <shi> as a significant difference in the normalization.
-    normalized = RE_MDEL.sub('', normalized)
+    # 2023-03-16 ebb: We have moved mdel to inlineVariationEvent, and do not want to normalize its token, so we are commenting out the next line.
+    # normalized = RE_MDEL.sub('', normalized)
     # 2022-08-08 ebb: <mdel> elements are tiny struck-out characters in the S-GA edition.
     # We do not think these are significant for comparison with the other editions, so we normalize them out.
     normalized = RE_DOTDASH.sub('. ', normalized)


### PR DESCRIPTION
@Yuying-Jin and I worked on this a little more this afternoon, deciding it is really more informative to allow `<mod>` to be output in the reading text (inside `<rdg>` elements), and to treat `<mdel>....</mdel>` as an inlineVariationEvent (and hence in longToken style as we do `<del>...</del>`. We tested this on C20 and found it more informative, without influencing the alignment much. 